### PR TITLE
Extract shared header into reusable partial

### DIFF
--- a/beyond.html
+++ b/beyond.html
@@ -10,23 +10,23 @@
 <!-- End Cloudflare Web Analytics -->
 <style>
 :root {
-  --space: 2rem;
-  --gold: #d4af37;
-  --navy: #232a6f;
-  --navy-d: #1f224f;
+	--space: 2rem;
+	--gold: #d4af37;
+	--navy: #232a6f;
+	--navy-d: #1f224f;
 }
 
 html, body {height: 100%;}
 body {
-  margin: 0;
-  overflow-x: hidden;
-  font-family: system-ui, sans-serif;
-  color: #fff;
-  background: var(--navy);
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
+	margin: 0;
+	overflow-x: hidden;
+	font-family: system-ui, sans-serif;
+	color: #fff;
+	background: var(--navy);
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
 }
 footer {margin-top: auto;}
 *, *::before, *::after {user-select:none;box-sizing:border-box;}
@@ -36,310 +36,268 @@ section {padding: var(--space) 0;}
 .separator {width: 100%; height: 4px; background: var(--gold); margin: var(--space) 0;}
 
 /* =========================
-   Header
-   ========================= */
+		Header
+		========================= */
 header {
-  padding: 2rem 0;
-  position: relative;
+	padding: 2rem 0;
+	position: relative;
 }
 .nav-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 2rem;
-  height: 70px;
-  position: relative;
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 0 2rem;
+	height: 70px;
+	position: relative;
 }
 .nav-center {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  text-align: center;
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	text-align: center;
 }
 .site-title {
-  width: clamp(500px, 65%, 800px);
-  height: auto;
-  transition: transform 0.2s;
-  display: block;
-  margin: 0 auto;
+	width: clamp(500px, 65%, 800px);
+	height: auto;
+	transition: transform 0.2s;
+	display: block;
+	margin: 0 auto;
 }
 .site-title:hover {transform: scale(1.05);}
 .nav-left {
-  position: absolute;
-  right: 50%;
-  transform: translateX(-320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	right: 50%;
+	transform: translateX(-320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-right {
-  position: absolute;
-  left: 50%;
-  transform: translateX(320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	left: 50%;
+	transform: translateX(320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-links a {
-  color: #fff;
-  text-decoration: none;
-  font-weight: 600;
-  font-size: 1.25rem;
-  white-space: nowrap;
-  transition: color 0.2s;
+	color: #fff;
+	text-decoration: none;
+	font-weight: 600;
+	font-size: 1.25rem;
+	white-space: nowrap;
+	transition: color 0.2s;
 }
 .nav-links a:hover {color: var(--gold);}
 
 /* Mobile merged nav hidden by default */
 .nav-all {
-  display: none;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 0.5rem;
+	display: none;
+	flex-direction: column;
+	align-items: center;
+	margin-top: 0.5rem;
 }
 .nav-all a {margin: 0.5rem 0; font-size: 1.1rem;}
 
 /* Hamburger button */
 .menu-btn {
-  display: none;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  cursor: pointer;
+	display: none;
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	background: none;
+	border: none;
+	cursor: pointer;
 }
 .menu-btn span {
-  display: block;
-  width: 28px;
-  height: 3px;
-  background: #fff;
-  margin: 6px 0;
-  transition: 0.3s;
+	display: block;
+	width: 28px;
+	height: 3px;
+	background: #fff;
+	margin: 6px 0;
+	transition: 0.3s;
 }
 
 /* Mobile styles */
 @media (max-width: 1100px) {
-  .nav-left, .nav-right { display: none; }
-  .nav-container { height: auto; }
-  .nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
-  .site-title { width: clamp(300px, 80%, 500px); }
-  .menu-btn { display: block; }
-  header { padding: 1.5rem 0 0.75rem; }
+	.nav-left, .nav-right { display: none; }
+	.nav-container { height: auto; }
+	.nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
+	.site-title { width: clamp(300px, 80%, 500px); }
+	.menu-btn { display: block; }
+	header { padding: 1.5rem 0 0.75rem; }
 }
 
 /* =========================
-   Social bar
-   ========================= */
+		Social bar
+		========================= */
 .social-section {background: var(--navy-d); padding: 0.75rem 0;}
 .social {
-  display: flex;
-  justify-content: center;
-  gap: 1.5rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
+	display: flex;
+	justify-content: center;
+	gap: 1.5rem;
+	margin: 0;
+	padding: 0;
+	list-style: none;
 }
 .social img {height: 48px; transition: transform .2s;}
 .social img:hover {transform: scale(1.1);}
 
 /* =========================
-   Parchment
-   ========================= */
+		Parchment
+		========================= */
 .parchment {
-  max-width: 1200px;
-  margin: 0 auto;
-  position: relative;
-  line-height: 0;
-  margin-bottom: 2rem;
+	max-width: 1200px;
+	margin: 0 auto;
+	position: relative;
+	line-height: 0;
+	margin-bottom: 2rem;
 }
 .parchment-top,
 .parchment-bottom {
-  display: block;
-  width: 100%;
-  height: auto;
-  image-rendering: pixelated;
+	display: block;
+	width: 100%;
+	height: auto;
+	image-rendering: pixelated;
 }
 .parchment-middle {
-  background-image: url("page_middle.png");
-  background-repeat: repeat-y;
-  background-size: 100% auto;
-  image-rendering: pixelated;
-  display: block;
-  width: 100%;
-  position: relative;
+	background-image: url("page_middle.png");
+	background-repeat: repeat-y;
+	background-size: 100% auto;
+	image-rendering: pixelated;
+	display: block;
+	width: 100%;
+	position: relative;
 }
 .parchment-content {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 92%;
-  max-width: 92%;
-  padding: 2rem;
-  color: #3c3629;
-  text-align: center;
-  font-size: 1.25rem;
-  line-height: 1.7;
+	position: absolute;
+	top: 0;
+	left: 50%;
+	transform: translateX(-50%);
+	width: 92%;
+	max-width: 92%;
+	padding: 2rem;
+	color: #3c3629;
+	text-align: center;
+	font-size: 1.25rem;
+	line-height: 1.7;
 }
 .parchment-content h1 {
-  font-size: 2.5rem;
-  margin: 1rem 0;
-  color: #3c3629;
+	font-size: 2.5rem;
+	margin: 1rem 0;
+	color: #3c3629;
 }
 .parchment-content h2 {
-  font-size: 1.75rem;
-  margin: 2rem 0 1rem;
-  color: #3c3629;
+	font-size: 1.75rem;
+	margin: 2rem 0 1rem;
+	color: #3c3629;
 }
 .parchment-content p {
-  margin: 0 0 1.25rem;
-  font-size: 1.1rem;
-  line-height: 1.6;
+	margin: 0 0 1.25rem;
+	font-size: 1.1rem;
+	line-height: 1.6;
 }
 
 /* =========================
-   Footer
-   ========================= */
+		Footer
+		========================= */
 footer {background: var(--navy-d); padding: 2rem 0; font-size: .875rem; color: #ddd;}
 </style>
 </head>
 
 <body>
-<header>
-  <div class="nav-container">
-    <div class="nav-left nav-links">
-      <a href="development.html">Development</a>
-    </div>
-    <div class="nav-center">
-      <a href="index.html">
-        <img src="title.png" alt="Sealubbers Title" class="site-title" id="site-title">
-      </a>
-    </div>
-    <div class="nav-right nav-links"></div>
-    <!-- Hamburger -->
-    <button class="menu-btn" id="menu-btn" aria-label="Toggle menu">
-      <span></span><span></span><span></span>
-    </button>
-    <div class="nav-all nav-links" id="mobile-nav">
-      <a href="development.html">Development</a>
-    </div>
-  </div>
-</header>
+<div id="header-placeholder"></div>
 
 <!-- Social -->
 <section class="social-section">
-  <div class="container">
-    <ul class="social">
-      <li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
-      <li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
-      <li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
-      <li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
-      <li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
-    </ul>
-  </div>
+	<div class="container">
+		<ul class="social">
+			<li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
+			<li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
+			<li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
+			<li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
+			<li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
+		</ul>
+	</div>
 </section>
 
 <!-- Beyond Content -->
 <section>
-  <div class="parchment">
-    <img src="page_top.png" alt="" class="parchment-top">
-    <div class="parchment-middle"></div>
-    <img src="page_bottom.png" alt="" class="parchment-bottom">
-    <div class="parchment-content">
-      <h1>Beyond — Post-Release Roadmap</h1>
-      <p>“Beyond” is everything that comes after full release. The goal is simple: keep Krucia growing — more people to meet, more islands to chart, more quests to chase, and new systems that deepen the game without bloating it. Updates will focus on replayability, a healthy endgame, and steady iteration with the community.</p>
+	<div class="parchment">
+		<img src="page_top.png" alt="" class="parchment-top">
+		<div class="parchment-middle"></div>
+		<img src="page_bottom.png" alt="" class="parchment-bottom">
+		<div class="parchment-content">
+			<h1>Beyond — Post-Release Roadmap</h1>
+			<p>“Beyond” is everything that comes after full release. The goal is simple: keep Krucia growing — more people to meet, more islands to chart, more quests to chase, and new systems that deepen the game without bloating it. Updates will focus on replayability, a healthy endgame, and steady iteration with the community.</p>
 
-      <h2>Near-Term: Fleshing Out Krucia</h2>
-      <p><strong>More Life in Ports</strong> — New NPC roles (cartographers, salvage brokers, fishmongers, star-seers), dynamic tavern events, traveling vendors, and rumor chains that evolve as regions shift.</p>
-      <p><strong>New Islands &amp; Biomes</strong> — Mist archipelagos, tidal flats, obsidian shoals, and shrines to the stars. Island traits like high winds, reef mazes, and starfall nights that change routes and risk.</p>
-      <p><strong>Quest Packs</strong> — Multi-step stories that intersect factions and trade lanes, plus treasure trails that stitch riddles and fragments across multiple islands.</p>
+			<h2>Near-Term: Fleshing Out Krucia</h2>
+			<p><strong>More Life in Ports</strong> — New NPC roles (cartographers, salvage brokers, fishmongers, star-seers), dynamic tavern events, traveling vendors, and rumor chains that evolve as regions shift.</p>
+			<p><strong>New Islands &amp; Biomes</strong> — Mist archipelagos, tidal flats, obsidian shoals, and shrines to the stars. Island traits like high winds, reef mazes, and starfall nights that change routes and risk.</p>
+			<p><strong>Quest Packs</strong> — Multi-step stories that intersect factions and trade lanes, plus treasure trails that stitch riddles and fragments across multiple islands.</p>
 
-      <h2>Systems Additions</h2>
-      <p><strong>Sea Monsters (Story + Bosses)</strong> — Hermit Crab Dreadnaught (shell-swap phases, sand squalls), Coral Hive-Mind (spawns reeflings, hardens by absorbing hull scrap), and Abyssal Ray (reload-slow aura, tail-whip shockwaves).</p>
-      <p><strong>Fishing 1.0</strong> — Lures, bait, and rod tiers; behavior by time, weather, current, and biome. Rare leviathans as special hunts. Catches feed cooking buffs, quests, and regional trade demands.</p>
-      <p><strong>Events at Sea</strong> — Starfall nights (meteoric salvage), fog bells (mystery convoys), and regattas (race quests).</p>
+			<h2>Systems Additions</h2>
+			<p><strong>Sea Monsters (Story + Bosses)</strong> — Hermit Crab Dreadnaught (shell-swap phases, sand squalls), Coral Hive-Mind (spawns reeflings, hardens by absorbing hull scrap), and Abyssal Ray (reload-slow aura, tail-whip shockwaves).</p>
+			<p><strong>Fishing 1.0</strong> — Lures, bait, and rod tiers; behavior by time, weather, current, and biome. Rare leviathans as special hunts. Catches feed cooking buffs, quests, and regional trade demands.</p>
+			<p><strong>Events at Sea</strong> — Starfall nights (meteoric salvage), fog bells (mystery convoys), and regattas (race quests).</p>
 
-      <h2>Endgame &amp; Replayability</h2>
-      <p><strong>Endgame Loops</strong> — Monster-hunt contracts with escalating bounties, legendary ship gauntlets, and rotating world modifiers.</p>
-      <p><strong>Stars &amp; Achievements</strong> — New star categories for regional mastery, flawless hunts, perfect trade runs, and time-trial sails. Multiple playthroughs encouraged to light the heavens fully.</p>
-      <p><strong>Scaling Challenges</strong> — “Hard seas” toggles: ironwind storms, scarce ports, harsher repairs, and rarer supplies.</p>
-      <p><strong>Weekly Rotations</strong> — Featured islands, boss spotlights, and rotating trade booms that reshape routes.</p>
+			<h2>Endgame &amp; Replayability</h2>
+			<p><strong>Endgame Loops</strong> — Monster-hunt contracts with escalating bounties, legendary ship gauntlets, and rotating world modifiers.</p>
+			<p><strong>Stars &amp; Achievements</strong> — New star categories for regional mastery, flawless hunts, perfect trade runs, and time-trial sails. Multiple playthroughs encouraged to light the heavens fully.</p>
+			<p><strong>Scaling Challenges</strong> — “Hard seas” toggles: ironwind storms, scarce ports, harsher repairs, and rarer supplies.</p>
+			<p><strong>Weekly Rotations</strong> — Featured islands, boss spotlights, and rotating trade booms that reshape routes.</p>
 
-      <h2>Balance, QoL, and Longevity</h2>
-      <p>Regular combat/economy balance passes guided by telemetry and feedback. Quality-of-life upgrades like map annotations, a route planner, loadout presets (cannons/sails), loot filters, and accessibility features (font size, colorblind palettes, aim assists). Ongoing performance and save stability improvements for large worlds and fleets.</p>
+			<h2>Balance, QoL, and Longevity</h2>
+			<p>Regular combat/economy balance passes guided by telemetry and feedback. Quality-of-life upgrades like map annotations, a route planner, loadout presets (cannons/sails), loot filters, and accessibility features (font size, colorblind palettes, aim assists). Ongoing performance and save stability improvements for large worlds and fleets.</p>
 
-      <h2>Community &amp; Live Ops</h2>
-      <p>Public roadmap with <em>Now / Next / Later</em> milestone cards. In-game feedback notes and opt-in test branches for major features. Community challenges that unlock cosmetics or limited-time events. Short lore drops from Asteros that tease incoming content.</p>
+			<h2>Community &amp; Live Ops</h2>
+			<p>Public roadmap with <em>Now / Next / Later</em> milestone cards. In-game feedback notes and opt-in test branches for major features. Community challenges that unlock cosmetics or limited-time events. Short lore drops from Asteros that tease incoming content.</p>
 
-      <h2>Content Cadence</h2>
-      <p><strong>Minor updates</strong> — Bugfixes, QoL, and 1–2 new quests or POIs.</p>
-      <p><strong>Content updates</strong> — New island sets, a monster, fishing gear tier, and questlines.</p>
-      <p><strong>Feature updates</strong> — Major systems like Fishing 1.0, Sea Monsters packs, and Endgame sets.</p>
-      <p><strong>Events</strong> — Limited-time modifiers, festive ports, and special treasure routes.</p>
+			<h2>Content Cadence</h2>
+			<p><strong>Minor updates</strong> — Bugfixes, QoL, and 1–2 new quests or POIs.</p>
+			<p><strong>Content updates</strong> — New island sets, a monster, fishing gear tier, and questlines.</p>
+			<p><strong>Feature updates</strong> — Major systems like Fishing 1.0, Sea Monsters packs, and Endgame sets.</p>
+			<p><strong>Events</strong> — Limited-time modifiers, festive ports, and special treasure routes.</p>
 
-      <h2>Far Future: Big Expansions</h2>
-      <p><strong>Multiplayer PvP Mode (Arcade Scale)</strong> — Fast sessions on a compact sea; collect cargo to “grow,” riskier lanes yield more. Safe harbors, power-up flotsam, rolling leaderboards, and cosmetic-only rewards earned through play.</p>
-      <p><strong>New Worlds Forged by Asteros</strong> — Aurora Seas (icebreakers, whale routes), Monsoon Archipelagos (seasonal winds and trade), and Crystal Atolls (light-reef puzzles, prismatic storms). Cross-world hooks: carry legend/stars, unlock interworld cosmetics and lore artifacts.</p>
+			<h2>Far Future: Big Expansions</h2>
+			<p><strong>Multiplayer PvP Mode (Arcade Scale)</strong> — Fast sessions on a compact sea; collect cargo to “grow,” riskier lanes yield more. Safe harbors, power-up flotsam, rolling leaderboards, and cosmetic-only rewards earned through play.</p>
+			<p><strong>New Worlds Forged by Asteros</strong> — Aurora Seas (icebreakers, whale routes), Monsoon Archipelagos (seasonal winds and trade), and Crystal Atolls (light-reef puzzles, prismatic storms). Cross-world hooks: carry legend/stars, unlock interworld cosmetics and lore artifacts.</p>
 
-      <h2>Conclusion</h2>
-      <p>Beyond release, Krucia keeps breathing: richer ports, stranger seas, smarter quests, fiercer monsters, and a sturdier endgame that rewards mastery. The compass points forward — and the sky still has room for more stars.</p>
-    </div>
-  </div>
+			<h2>Conclusion</h2>
+			<p>Beyond release, Krucia keeps breathing: richer ports, stranger seas, smarter quests, fiercer monsters, and a sturdier endgame that rewards mastery. The compass points forward — and the sky still has room for more stars.</p>
+		</div>
+	</div>
 </section>
 
 <footer><div class="container">© 2025 Sealubbers. All rights reserved.</div></footer>
 
+<script src="header.js"></script>
+
 <script>
-/* Mobile menu toggle */
-const menuBtn=document.getElementById('menu-btn');
-const mobileNav=document.getElementById('mobile-nav');
-menuBtn.addEventListener('click',()=>{
-  mobileNav.style.display = mobileNav.style.display==='flex' ? 'none' : 'flex';
-});
-
-/* Position menu button */
-function positionMenuBtn(){
-  const btn=document.getElementById('menu-btn');
-  const title=document.getElementById('site-title');
-  if(window.innerWidth<=1100){
-    const titleRight=title.getBoundingClientRect().right;
-    const screenRight=window.innerWidth;
-    const midpoint=(titleRight+screenRight)/2;
-    btn.style.left=midpoint+"px";
-    btn.style.transform="translateX(-50%) translateY(-50%)";
-  }else{
-    btn.style.left="";
-    btn.style.transform="translateY(-50%)";
-    mobileNav.style.display="";
-  }
-}
-window.addEventListener('resize',positionMenuBtn);
-window.addEventListener('load',positionMenuBtn);
-
 /* Swap social icons */
 document.querySelectorAll('.social img').forEach(img=>{
-  img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
-  img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
+	img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
+	img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
 });
 
 /* Adjust parchment height */
-function adjustParchmentHeight() {
-  document.querySelectorAll('.parchment').forEach(parchment=>{
-    const content=parchment.querySelector('.parchment-content');
-    const middle=parchment.querySelector('.parchment-middle');
-    const top=parchment.querySelector('.parchment-top');
-    const bottom=parchment.querySelector('.parchment-bottom');
-    if (!content||!middle||!top||!bottom) return;
-    const contentHeight=content.scrollHeight;
-    const topHeight=top.offsetHeight;
-    const bottomHeight=bottom.offsetHeight;
-    const middleHeight=Math.max(100, contentHeight - topHeight - bottomHeight);
-    middle.style.height=middleHeight+'px';
-  });
+function adjustParchmentHeight(){
+	document.querySelectorAll('.parchment').forEach(parchment=>{
+		const content=parchment.querySelector('.parchment-content');
+		const middle=parchment.querySelector('.parchment-middle');
+		const top=parchment.querySelector('.parchment-top');
+		const bottom=parchment.querySelector('.parchment-bottom');
+		if(!content||!middle||!top||!bottom){return;}
+		const contentHeight=content.scrollHeight;
+		const topHeight=top.offsetHeight;
+		const bottomHeight=bottom.offsetHeight;
+		const middleHeight=Math.max(100, contentHeight - topHeight - bottomHeight);
+		middle.style.height=middleHeight+'px';
+	});
 }
 window.addEventListener('load',()=>setTimeout(adjustParchmentHeight,100));
 window.addEventListener('resize',adjustParchmentHeight);
 </script>
 </body>
 </html>
+

--- a/combat.html
+++ b/combat.html
@@ -10,23 +10,23 @@
 <!-- End Cloudflare Web Analytics -->
 <style>
 :root {
-  --space: 2rem;
-  --gold: #d4af37;
-  --navy: #232a6f;
-  --navy-d: #1f224f;
+	--space: 2rem;
+	--gold: #d4af37;
+	--navy: #232a6f;
+	--navy-d: #1f224f;
 }
 
 html, body {height: 100%;}
 body {
-  margin: 0;
-  overflow-x: hidden;
-  font-family: system-ui, sans-serif;
-  color: #fff;
-  background: var(--navy);
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
+	margin: 0;
+	overflow-x: hidden;
+	font-family: system-ui, sans-serif;
+	color: #fff;
+	background: var(--navy);
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
 }
 footer {margin-top: auto;}
 *, *::before, *::after {user-select:none;box-sizing:border-box;}
@@ -36,305 +36,263 @@ section {padding: var(--space) 0;}
 .separator {width: 100%; height: 4px; background: var(--gold); margin: var(--space) 0;}
 
 /* =========================
-   Header
-   ========================= */
+		Header
+		========================= */
 header {
-  padding: 2rem 0;
-  position: relative;
+	padding: 2rem 0;
+	position: relative;
 }
 .nav-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 2rem;
-  height: 70px;
-  position: relative;
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 0 2rem;
+	height: 70px;
+	position: relative;
 }
 .nav-center {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  text-align: center;
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	text-align: center;
 }
 .site-title {
-  width: clamp(500px, 65%, 800px);
-  height: auto;
-  transition: transform 0.2s;
-  display: block;
-  margin: 0 auto;
+	width: clamp(500px, 65%, 800px);
+	height: auto;
+	transition: transform 0.2s;
+	display: block;
+	margin: 0 auto;
 }
 .site-title:hover {transform: scale(1.05);}
 .nav-left {
-  position: absolute;
-  right: 50%;
-  transform: translateX(-320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	right: 50%;
+	transform: translateX(-320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-right {
-  position: absolute;
-  left: 50%;
-  transform: translateX(320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	left: 50%;
+	transform: translateX(320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-links a {
-  color: #fff;
-  text-decoration: none;
-  font-weight: 600;
-  font-size: 1.25rem;
-  white-space: nowrap;
-  transition: color 0.2s;
+	color: #fff;
+	text-decoration: none;
+	font-weight: 600;
+	font-size: 1.25rem;
+	white-space: nowrap;
+	transition: color 0.2s;
 }
 .nav-links a:hover {color: var(--gold);}
 
 /* Mobile merged nav hidden by default */
 .nav-all {
-  display: none;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 0.5rem;
+	display: none;
+	flex-direction: column;
+	align-items: center;
+	margin-top: 0.5rem;
 }
 .nav-all a {margin: 0.5rem 0; font-size: 1.1rem;}
 
 /* Hamburger button */
 .menu-btn {
-  display: none;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  cursor: pointer;
+	display: none;
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	background: none;
+	border: none;
+	cursor: pointer;
 }
 .menu-btn span {
-  display: block;
-  width: 28px;
-  height: 3px;
-  background: #fff;
-  margin: 6px 0;
-  transition: 0.3s;
+	display: block;
+	width: 28px;
+	height: 3px;
+	background: #fff;
+	margin: 6px 0;
+	transition: 0.3s;
 }
 
 /* Mobile styles */
 @media (max-width: 1100px) {
-  .nav-left, .nav-right { display: none; }
-  .nav-container { height: auto; }
-  .nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
-  .site-title { width: clamp(300px, 80%, 500px); }
-  .menu-btn { display: block; }
-  header { padding: 1.5rem 0 0.75rem; }
+	.nav-left, .nav-right { display: none; }
+	.nav-container { height: auto; }
+	.nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
+	.site-title { width: clamp(300px, 80%, 500px); }
+	.menu-btn { display: block; }
+	header { padding: 1.5rem 0 0.75rem; }
 }
 
 /* =========================
-   Social bar
-   ========================= */
+		Social bar
+		========================= */
 .social-section {background: var(--navy-d); padding: 0.75rem 0;}
 .social {
-  display: flex;
-  justify-content: center;
-  gap: 1.5rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
+	display: flex;
+	justify-content: center;
+	gap: 1.5rem;
+	margin: 0;
+	padding: 0;
+	list-style: none;
 }
 .social img {height: 48px; transition: transform .2s;}
 .social img:hover {transform: scale(1.1);}
 
 /* =========================
-   Parchment
-   ========================= */
+		Parchment
+		========================= */
 .parchment {
-  max-width: 1200px;
-  margin: 0 auto;
-  position: relative;
-  line-height: 0;
-  margin-bottom: 2rem;
+	max-width: 1200px;
+	margin: 0 auto;
+	position: relative;
+	line-height: 0;
+	margin-bottom: 2rem;
 }
 .parchment-top,
 .parchment-bottom {
-  display: block;
-  width: 100%;
-  height: auto;
-  image-rendering: pixelated;
+	display: block;
+	width: 100%;
+	height: auto;
+	image-rendering: pixelated;
 }
 .parchment-middle {
-  background-image: url("page_middle.png");
-  background-repeat: repeat-y;
-  background-size: 100% auto;
-  image-rendering: pixelated;
-  display: block;
-  width: 100%;
-  position: relative;
+	background-image: url("page_middle.png");
+	background-repeat: repeat-y;
+	background-size: 100% auto;
+	image-rendering: pixelated;
+	display: block;
+	width: 100%;
+	position: relative;
 }
 .parchment-content {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 92%;
-  max-width: 92%;
-  padding: 2rem;
-  color: #3c3629;
-  text-align: center;
-  font-size: 1.25rem;
-  line-height: 1.7;
+	position: absolute;
+	top: 0;
+	left: 50%;
+	transform: translateX(-50%);
+	width: 92%;
+	max-width: 92%;
+	padding: 2rem;
+	color: #3c3629;
+	text-align: center;
+	font-size: 1.25rem;
+	line-height: 1.7;
 }
 .parchment-content h1 {
-  font-size: 2.5rem;
-  margin: 1rem 0;
-  color: #3c3629;
+	font-size: 2.5rem;
+	margin: 1rem 0;
+	color: #3c3629;
 }
 .parchment-content h2 {
-  font-size: 1.75rem;
-  margin: 2rem 0 1rem;
-  color: #3c3629;
+	font-size: 1.75rem;
+	margin: 2rem 0 1rem;
+	color: #3c3629;
 }
 .parchment-content p {
-  margin: 0 0 1.25rem;
-  font-size: 1.1rem;
-  line-height: 1.6;
+	margin: 0 0 1.25rem;
+	font-size: 1.1rem;
+	line-height: 1.6;
 }
 
 /* =========================
-   Footer
-   ========================= */
+		Footer
+		========================= */
 footer {background: var(--navy-d); padding: 2rem 0; font-size: .875rem; color: #ddd;}
 </style>
 </head>
 
 <body>
-<header>
-  <div class="nav-container">
-    <div class="nav-left nav-links">
-      <a href="development.html">Development</a>
-    </div>
-    <div class="nav-center">
-      <a href="index.html">
-        <img src="title.png" alt="Sealubbers Title" class="site-title" id="site-title">
-      </a>
-    </div>
-    <div class="nav-right nav-links"></div>
-    <!-- Hamburger -->
-    <button class="menu-btn" id="menu-btn" aria-label="Toggle menu">
-      <span></span><span></span><span></span>
-    </button>
-    <div class="nav-all nav-links" id="mobile-nav">
-      <a href="development.html">Development</a>
-    </div>
-  </div>
-</header>
+<div id="header-placeholder"></div>
 
 <!-- Social -->
 <section class="social-section">
-  <div class="container">
-    <ul class="social">
-      <li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
-      <li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
-      <li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
-      <li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
-      <li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
-    </ul>
-  </div>
+	<div class="container">
+		<ul class="social">
+			<li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
+			<li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
+			<li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
+			<li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
+			<li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
+		</ul>
+	</div>
 </section>
 
 <!-- Combat Content -->
 <section>
-  <div class="parchment">
-    <img src="page_top.png" alt="" class="parchment-top">
-    <div class="parchment-middle"></div>
-    <img src="page_bottom.png" alt="" class="parchment-bottom">
-    <div class="parchment-content">
-      <h1>Combat in Krucia</h1>
-      <p>Combat in Krucia is split between the clash of ships on the open sea and the chaos of crews fighting blade to blade. Battles can unfold in many different ways depending on who you face, how your crew is built, and the choices you make as captain.</p>
+	<div class="parchment">
+		<img src="page_top.png" alt="" class="parchment-top">
+		<div class="parchment-middle"></div>
+		<img src="page_bottom.png" alt="" class="parchment-bottom">
+		<div class="parchment-content">
+			<h1>Combat in Krucia</h1>
+			<p>Combat in Krucia is split between the clash of ships on the open sea and the chaos of crews fighting blade to blade. Battles can unfold in many different ways depending on who you face, how your crew is built, and the choices you make as captain.</p>
 
-      <h2>Types of Battles</h2>
-      <p><strong>Ship-to-Ship Combat</strong> — Long-range engagements with cannons, sails, and maneuvering.</p>
-      <p><strong>Boarding Battles</strong> — Close-quarters fights where crews clash across the decks.</p>
-      <p><strong>Boss Battles</strong> — Large encounters that test your ability to command at sea and on foot.</p>
+			<h2>Types of Battles</h2>
+			<p><strong>Ship-to-Ship Combat</strong> — Long-range engagements with cannons, sails, and maneuvering.</p>
+			<p><strong>Boarding Battles</strong> — Close-quarters fights where crews clash across the decks.</p>
+			<p><strong>Boss Battles</strong> — Large encounters that test your ability to command at sea and on foot.</p>
 
-      <h2>Enemy Ships and Behavior</h2>
-      <p>Not every ship you encounter will fight the same way. Some will flee or surrender, some will try to pay you off, and others attack aggressively on sight. Certain captains will hunt you based on your past actions, and some ships only target you depending on your reputation with their faction. Ships also appear along predictable routes — patrol lines, trade lanes, and ambush points — letting you plan where and when to pick your fights.</p>
+			<h2>Enemy Ships and Behavior</h2>
+			<p>Not every ship you encounter will fight the same way. Some will flee or surrender, some will try to pay you off, and others attack aggressively on sight. Certain captains will hunt you based on your past actions, and some ships only target you depending on your reputation with their faction. Ships also appear along predictable routes — patrol lines, trade lanes, and ambush points — letting you plan where and when to pick your fights.</p>
 
-      <h2>Scouting and Information</h2>
-      <p>Before combat, you can scout an enemy ship. The details you learn depend on your crew’s abilities: ship health, crew size and abilities, and what cargo or treasure they’re carrying. With the right information, you can choose to fight, flee, or pursue a different target. Some quests will also send you after specific ships at specific times.</p>
+			<h2>Scouting and Information</h2>
+			<p>Before combat, you can scout an enemy ship. The details you learn depend on your crew’s abilities: ship health, crew size and abilities, and what cargo or treasure they’re carrying. With the right information, you can choose to fight, flee, or pursue a different target. Some quests will also send you after specific ships at specific times.</p>
 
-      <h2>Naval Combat</h2>
-      <p><strong>Maneuvering</strong> — Positioning is everything. Angle your ship for broadsides while dodging return fire.</p>
-      <p><strong>Cannons</strong> — Time your salvos, manage reloads, and aim for vulnerable moments to control the flow of battle.</p>
-      <p><strong>Environmental Hazards</strong> — Waves, reefs, fog, and storms can all turn the tide.</p>
-      <p><strong>Upgrades</strong> — Permanent improvements like stronger hulls, faster sails, and reinforced cannons raise your power.</p>
-      <p><strong>Crew Impact</strong> — Reload speed, repair efficiency, turning sharpness, and accuracy all scale with your crew’s skills.</p>
+			<h2>Naval Combat</h2>
+			<p><strong>Maneuvering</strong> — Positioning is everything. Angle your ship for broadsides while dodging return fire.</p>
+			<p><strong>Cannons</strong> — Time your salvos, manage reloads, and aim for vulnerable moments to control the flow of battle.</p>
+			<p><strong>Environmental Hazards</strong> — Waves, reefs, fog, and storms can all turn the tide.</p>
+			<p><strong>Upgrades</strong> — Permanent improvements like stronger hulls, faster sails, and reinforced cannons raise your power.</p>
+			<p><strong>Crew Impact</strong> — Reload speed, repair efficiency, turning sharpness, and accuracy all scale with your crew’s skills.</p>
 
-      <h2>Boarding Combat</h2>
-      <p>When you close in, you can board the enemy ship. Your sailors and theirs clash across the decks while you direct the fight.</p>
-      <p><strong>Captain’s Orders</strong> — Certain crewmates grant active abilities such as tossing sand to blind enemies, healing an ally, rallying morale, or drawing attention to a specific fighter.</p>
-      <p><strong>Hazards</strong> — Expect falling masts, spreading fires, explosions, and collapsing decks.</p>
-      <p><strong>Positioning</strong> — Move your crew to avoid danger and press advantages as the battlefield shifts.</p>
+			<h2>Boarding Combat</h2>
+			<p>When you close in, you can board the enemy ship. Your sailors and theirs clash across the decks while you direct the fight.</p>
+			<p><strong>Captain’s Orders</strong> — Certain crewmates grant active abilities such as tossing sand to blind enemies, healing an ally, rallying morale, or drawing attention to a specific fighter.</p>
+			<p><strong>Hazards</strong> — Expect falling masts, spreading fires, explosions, and collapsing decks.</p>
+			<p><strong>Positioning</strong> — Move your crew to avoid danger and press advantages as the battlefield shifts.</p>
 
-      <h2>Strategy and Playstyles</h2>
-      <p>Build the crew that fits your plan: expert sailors who dominate the sea, fearsome fighters who excel in boarding, or a versatile mix that adapts on the fly. Some encounters — especially bosses — will challenge both your sailing and swordplay.</p>
+			<h2>Strategy and Playstyles</h2>
+			<p>Build the crew that fits your plan: expert sailors who dominate the sea, fearsome fighters who excel in boarding, or a versatile mix that adapts on the fly. Some encounters — especially bosses — will challenge both your sailing and swordplay.</p>
 
-      <h2>Rewards of Victory</h2>
-      <p>Winning battles brings clear rewards: gold and cargo, weapons and artifacts, new quests and story progress — and sometimes new recruits from defeated foes. Each victory also opens the path to permanent ship upgrades and a growing reputation on the seas.</p>
-    </div>
-  </div>
+			<h2>Rewards of Victory</h2>
+			<p>Winning battles brings clear rewards: gold and cargo, weapons and artifacts, new quests and story progress — and sometimes new recruits from defeated foes. Each victory also opens the path to permanent ship upgrades and a growing reputation on the seas.</p>
+		</div>
+	</div>
 </section>
 
 <footer><div class="container">© 2025 Sealubbers. All rights reserved.</div></footer>
 
+<script src="header.js"></script>
+
 <script>
-/* Mobile menu toggle */
-const menuBtn=document.getElementById('menu-btn');
-const mobileNav=document.getElementById('mobile-nav');
-menuBtn.addEventListener('click',()=>{
-  mobileNav.style.display = mobileNav.style.display==='flex' ? 'none' : 'flex';
-});
-
-/* Position menu button */
-function positionMenuBtn(){
-  const btn=document.getElementById('menu-btn');
-  const title=document.getElementById('site-title');
-  if(window.innerWidth<=1100){
-    const titleRight=title.getBoundingClientRect().right;
-    const screenRight=window.innerWidth;
-    const midpoint=(titleRight+screenRight)/2;
-    btn.style.left=midpoint+"px";
-    btn.style.transform="translateX(-50%) translateY(-50%)";
-  }else{
-    btn.style.left="";
-    btn.style.transform="translateY(-50%)";
-    mobileNav.style.display="";
-  }
-}
-window.addEventListener('resize',positionMenuBtn);
-window.addEventListener('load',positionMenuBtn);
-
 /* Swap social icons */
 document.querySelectorAll('.social img').forEach(img=>{
-  img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
-  img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
+	img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
+	img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
 });
 
 /* Adjust parchment height */
-function adjustParchmentHeight() {
-  document.querySelectorAll('.parchment').forEach(parchment=>{
-    const content=parchment.querySelector('.parchment-content');
-    const middle=parchment.querySelector('.parchment-middle');
-    const top=parchment.querySelector('.parchment-top');
-    const bottom=parchment.querySelector('.parchment-bottom');
-    if (!content||!middle||!top||!bottom) return;
-    const contentHeight=content.scrollHeight;
-    const topHeight=top.offsetHeight;
-    const bottomHeight=bottom.offsetHeight;
-    const middleHeight=Math.max(100, contentHeight - topHeight - bottomHeight);
-    middle.style.height=middleHeight+'px';
-  });
+function adjustParchmentHeight(){
+	document.querySelectorAll('.parchment').forEach(parchment=>{
+		const content=parchment.querySelector('.parchment-content');
+		const middle=parchment.querySelector('.parchment-middle');
+		const top=parchment.querySelector('.parchment-top');
+		const bottom=parchment.querySelector('.parchment-bottom');
+		if(!content||!middle||!top||!bottom){return;}
+		const contentHeight=content.scrollHeight;
+		const topHeight=top.offsetHeight;
+		const bottomHeight=bottom.offsetHeight;
+		const middleHeight=Math.max(100, contentHeight - topHeight - bottomHeight);
+		middle.style.height=middleHeight+'px';
+	});
 }
 window.addEventListener('load',()=>setTimeout(adjustParchmentHeight,100));
 window.addEventListener('resize',adjustParchmentHeight);
 </script>
 </body>
 </html>
+

--- a/crew.html
+++ b/crew.html
@@ -10,23 +10,23 @@
 <!-- End Cloudflare Web Analytics -->
 <style>
 :root {
-  --space: 2rem;
-  --gold: #d4af37;
-  --navy: #232a6f;
-  --navy-d: #1f224f;
+	--space: 2rem;
+	--gold: #d4af37;
+	--navy: #232a6f;
+	--navy-d: #1f224f;
 }
 
 html, body {height: 100%;}
 body {
-  margin: 0;
-  overflow-x: hidden;
-  font-family: system-ui, sans-serif;
-  color: #fff;
-  background: var(--navy);
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
+	margin: 0;
+	overflow-x: hidden;
+	font-family: system-ui, sans-serif;
+	color: #fff;
+	background: var(--navy);
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
 }
 footer {margin-top: auto;}
 *, *::before, *::after {user-select:none;box-sizing:border-box;}
@@ -36,296 +36,254 @@ section {padding: var(--space) 0;}
 .separator {width: 100%; height: 4px; background: var(--gold); margin: var(--space) 0;}
 
 /* =========================
-   Header
-   ========================= */
+		Header
+		========================= */
 header {
-  padding: 2rem 0;
-  position: relative;
+	padding: 2rem 0;
+	position: relative;
 }
 .nav-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 2rem;
-  height: 70px;
-  position: relative;
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 0 2rem;
+	height: 70px;
+	position: relative;
 }
 .nav-center {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  text-align: center;
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	text-align: center;
 }
 .site-title {
-  width: clamp(500px, 65%, 800px);
-  height: auto;
-  transition: transform 0.2s;
-  display: block;
-  margin: 0 auto;
+	width: clamp(500px, 65%, 800px);
+	height: auto;
+	transition: transform 0.2s;
+	display: block;
+	margin: 0 auto;
 }
 .site-title:hover {transform: scale(1.05);}
 .nav-left {
-  position: absolute;
-  right: 50%;
-  transform: translateX(-320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	right: 50%;
+	transform: translateX(-320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-right {
-  position: absolute;
-  left: 50%;
-  transform: translateX(320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	left: 50%;
+	transform: translateX(320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-links a {
-  color: #fff;
-  text-decoration: none;
-  font-weight: 600;
-  font-size: 1.25rem;
-  white-space: nowrap;
-  transition: color 0.2s;
+	color: #fff;
+	text-decoration: none;
+	font-weight: 600;
+	font-size: 1.25rem;
+	white-space: nowrap;
+	transition: color 0.2s;
 }
 .nav-links a:hover {color: var(--gold);}
 
 /* Mobile merged nav hidden by default */
 .nav-all {
-  display: none;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 0.5rem;
+	display: none;
+	flex-direction: column;
+	align-items: center;
+	margin-top: 0.5rem;
 }
 .nav-all a {margin: 0.5rem 0; font-size: 1.1rem;}
 
 /* Hamburger button */
 .menu-btn {
-  display: none;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  cursor: pointer;
+	display: none;
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	background: none;
+	border: none;
+	cursor: pointer;
 }
 .menu-btn span {
-  display: block;
-  width: 28px;
-  height: 3px;
-  background: #fff;
-  margin: 6px 0;
-  transition: 0.3s;
+	display: block;
+	width: 28px;
+	height: 3px;
+	background: #fff;
+	margin: 6px 0;
+	transition: 0.3s;
 }
 
 /* Mobile styles */
 @media (max-width: 1100px) {
-  .nav-left, .nav-right { display: none; }
-  .nav-container { height: auto; }
-  .nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
-  .site-title { width: clamp(300px, 80%, 500px); }
-  .menu-btn { display: block; }
-  header { padding: 1.5rem 0 0.75rem; }
+	.nav-left, .nav-right { display: none; }
+	.nav-container { height: auto; }
+	.nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
+	.site-title { width: clamp(300px, 80%, 500px); }
+	.menu-btn { display: block; }
+	header { padding: 1.5rem 0 0.75rem; }
 }
 
 /* =========================
-   Social bar
-   ========================= */
+		Social bar
+		========================= */
 .social-section {background: var(--navy-d); padding: 0.75rem 0;}
 .social {
-  display: flex;
-  justify-content: center;
-  gap: 1.5rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
+	display: flex;
+	justify-content: center;
+	gap: 1.5rem;
+	margin: 0;
+	padding: 0;
+	list-style: none;
 }
 .social img {height: 48px; transition: transform .2s;}
 .social img:hover {transform: scale(1.1);}
 
 /* =========================
-   Parchment
-   ========================= */
+		Parchment
+		========================= */
 .parchment {
-  max-width: 1200px;
-  margin: 0 auto;
-  position: relative;
-  line-height: 0;
-  margin-bottom: 2rem;
+	max-width: 1200px;
+	margin: 0 auto;
+	position: relative;
+	line-height: 0;
+	margin-bottom: 2rem;
 }
 .parchment-top,
 .parchment-bottom {
-  display: block;
-  width: 100%;
-  height: auto;
-  image-rendering: pixelated;
+	display: block;
+	width: 100%;
+	height: auto;
+	image-rendering: pixelated;
 }
 .parchment-middle {
-  background-image: url("page_middle.png");
-  background-repeat: repeat-y;
-  background-size: 100% auto;
-  image-rendering: pixelated;
-  display: block;
-  width: 100%;
-  position: relative;
+	background-image: url("page_middle.png");
+	background-repeat: repeat-y;
+	background-size: 100% auto;
+	image-rendering: pixelated;
+	display: block;
+	width: 100%;
+	position: relative;
 }
 .parchment-content {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 92%;
-  max-width: 92%;
-  padding: 2rem;
-  color: #3c3629;
-  text-align: center;
-  font-size: 1.25rem;
-  line-height: 1.7;
+	position: absolute;
+	top: 0;
+	left: 50%;
+	transform: translateX(-50%);
+	width: 92%;
+	max-width: 92%;
+	padding: 2rem;
+	color: #3c3629;
+	text-align: center;
+	font-size: 1.25rem;
+	line-height: 1.7;
 }
 .parchment-content h1 {
-  font-size: 2.5rem;
-  margin: 1rem 0;
-  color: #3c3629;
+	font-size: 2.5rem;
+	margin: 1rem 0;
+	color: #3c3629;
 }
 .parchment-content h2 {
-  font-size: 1.75rem;
-  margin: 2rem 0 1rem;
-  color: #3c3629;
+	font-size: 1.75rem;
+	margin: 2rem 0 1rem;
+	color: #3c3629;
 }
 .parchment-content p {
-  margin: 0 0 1.25rem;
-  font-size: 1.1rem;
-  line-height: 1.6;
+	margin: 0 0 1.25rem;
+	font-size: 1.1rem;
+	line-height: 1.6;
 }
 
 /* =========================
-   Footer
-   ========================= */
+		Footer
+		========================= */
 footer {background: var(--navy-d); padding: 2rem 0; font-size: .875rem; color: #ddd;}
 </style>
 </head>
 
 <body>
-<header>
-  <div class="nav-container">
-    <div class="nav-left nav-links">
-      <a href="development.html">Development</a>
-    </div>
-    <div class="nav-center">
-      <a href="index.html">
-        <img src="title.png" alt="Sealubbers Title" class="site-title" id="site-title">
-      </a>
-    </div>
-    <div class="nav-right nav-links"></div>
-    <!-- Hamburger -->
-    <button class="menu-btn" id="menu-btn" aria-label="Toggle menu">
-      <span></span><span></span><span></span>
-    </button>
-    <div class="nav-all nav-links" id="mobile-nav">
-      <a href="development.html">Development</a>
-    </div>
-  </div>
-</header>
+<div id="header-placeholder"></div>
 
 <!-- Social -->
 <section class="social-section">
-  <div class="container">
-    <ul class="social">
-      <li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
-      <li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
-      <li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
-      <li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
-      <li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
-    </ul>
-  </div>
+	<div class="container">
+		<ul class="social">
+			<li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
+			<li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
+			<li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
+			<li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
+			<li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
+		</ul>
+	</div>
 </section>
 
 <!-- Crew Content -->
 <section>
-  <div class="parchment">
-    <img src="page_top.png" alt="" class="parchment-top">
-    <div class="parchment-middle"></div>
-    <img src="page_bottom.png" alt="" class="parchment-bottom">
-    <div class="parchment-content">
-      <h1>The Crew of Krucia</h1>
-      <p>A captain is only as strong as their crew. In Krucia, your shipmates aren’t just background figures — they’re living characters who shape your journey. Each crewmate brings their own skills, quirks, and stories, making your crew one of the most important parts of the game.</p>
+	<div class="parchment">
+		<img src="page_top.png" alt="" class="parchment-top">
+		<div class="parchment-middle"></div>
+		<img src="page_bottom.png" alt="" class="parchment-bottom">
+		<div class="parchment-content">
+			<h1>The Crew of Krucia</h1>
+			<p>A captain is only as strong as their crew. In Krucia, your shipmates aren’t just background figures — they’re living characters who shape your journey. Each crewmate brings their own skills, quirks, and stories, making your crew one of the most important parts of the game.</p>
 
-      <h2>Recruiting Your Crew</h2>
-      <p>Crewmates can be found everywhere: in taverns, on the docks, wandering beaches, or rescued from shipwrecks. Some will join you for gold, others for favors or out of sheer curiosity. If you don’t hire them right away, they remain part of the world. You might spot them again in another port, or even see them serving on rival ships.</p>
+			<h2>Recruiting Your Crew</h2>
+			<p>Crewmates can be found everywhere: in taverns, on the docks, wandering beaches, or rescued from shipwrecks. Some will join you for gold, others for favors or out of sheer curiosity. If you don’t hire them right away, they remain part of the world. You might spot them again in another port, or even see them serving on rival ships.</p>
 
-      <h2>Crew Traits and Gifts</h2>
-      <p>Every crewmate is unique, defined by three qualities: <strong>Personality</strong>, <strong>Stats</strong>, and a <strong>Gift</strong>. Stats cover things like health, strength, sailing, and speed. Gifts are special traits tied to sailing, fighting, or exploration — ranging from faster cannon reloads to uncanny treasure-sense. No two crewmates are alike, and finding the right mix is key to surviving the seas.</p>
+			<h2>Crew Traits and Gifts</h2>
+			<p>Every crewmate is unique, defined by three qualities: <strong>Personality</strong>, <strong>Stats</strong>, and a <strong>Gift</strong>. Stats cover things like health, strength, sailing, and speed. Gifts are special traits tied to sailing, fighting, or exploration — ranging from faster cannon reloads to uncanny treasure-sense. No two crewmates are alike, and finding the right mix is key to surviving the seas.</p>
 
-      <h2>Crew Progression</h2>
-      <p>Crewmates grow stronger over time. Leveling them up increases stats and strengthens their gifts. Progression is straightforward — no complicated branches, just steady improvement as they sail and fight by your side.</p>
+			<h2>Crew Progression</h2>
+			<p>Crewmates grow stronger over time. Leveling them up increases stats and strengthens their gifts. Progression is straightforward — no complicated branches, just steady improvement as they sail and fight by your side.</p>
 
-      <h2>Managing Your Crew</h2>
-      <p>The number of crewmates you can hire depends on the size of your ship: smaller ships carry fewer, while larger vessels can hold more. Your roster is flexible — you’ll frequently hire and replace sailors depending on your goals. Firing a crewmate can be done with a simple dismissal, or with flair by making them walk the plank. You can also reward loyal crewmates with gold or rum to raise their morale. Dialogue options let you order cosmetic tasks, like scrubbing the deck, adding flavor without changing gameplay.</p>
+			<h2>Managing Your Crew</h2>
+			<p>The number of crewmates you can hire depends on the size of your ship: smaller ships carry fewer, while larger vessels can hold more. Your roster is flexible — you’ll frequently hire and replace sailors depending on your goals. Firing a crewmate can be done with a simple dismissal, or with flair by making them walk the plank. You can also reward loyal crewmates with gold or rum to raise their morale. Dialogue options let you order cosmetic tasks, like scrubbing the deck, adding flavor without changing gameplay.</p>
 
-      <h2>Crew Quests and Stories</h2>
-      <p>Many crewmates have personal quests that reveal their past or ambitions. Completing these quests can unlock stronger gifts, unique rewards, or special opportunities. These stories give every crewmate a place in the larger world of Krucia.</p>
+			<h2>Crew Quests and Stories</h2>
+			<p>Many crewmates have personal quests that reveal their past or ambitions. Completing these quests can unlock stronger gifts, unique rewards, or special opportunities. These stories give every crewmate a place in the larger world of Krucia.</p>
 
-      <h2>Loyalty and Mutiny</h2>
-      <p>Crew loyalty rises and falls with your success. Winning battles and rewarding your crew keeps spirits high. Repeated losses strain morale. If morale falls too low, mutiny becomes a real threat. A mutiny is a special event where your own crew turns against you, seeking your gold and your ship. To survive, you’ll have to fight back and reclaim command.</p>
+			<h2>Loyalty and Mutiny</h2>
+			<p>Crew loyalty rises and falls with your success. Winning battles and rewarding your crew keeps spirits high. Repeated losses strain morale. If morale falls too low, mutiny becomes a real threat. A mutiny is a special event where your own crew turns against you, seeking your gold and your ship. To survive, you’ll have to fight back and reclaim command.</p>
 
-      <h2>The Captain’s Legacy</h2>
-      <p>Building your crew is one of the core loops of Krucia. From recruiting fresh faces in distant taverns to leveling up your most trusted shipmates, your crew defines your strength on the seas. Gold may buy ships, but it’s the people aboard who will carry your story into legend.</p>
-    </div>
-  </div>
+			<h2>The Captain’s Legacy</h2>
+			<p>Building your crew is one of the core loops of Krucia. From recruiting fresh faces in distant taverns to leveling up your most trusted shipmates, your crew defines your strength on the seas. Gold may buy ships, but it’s the people aboard who will carry your story into legend.</p>
+		</div>
+	</div>
 </section>
 
 <footer><div class="container">© 2025 Sealubbers. All rights reserved.</div></footer>
 
+<script src="header.js"></script>
+
 <script>
-/* Mobile menu toggle */
-const menuBtn=document.getElementById('menu-btn');
-const mobileNav=document.getElementById('mobile-nav');
-menuBtn.addEventListener('click',()=>{
-  mobileNav.style.display = mobileNav.style.display==='flex' ? 'none' : 'flex';
-});
-
-/* Position menu button */
-function positionMenuBtn(){
-  const btn=document.getElementById('menu-btn');
-  const title=document.getElementById('site-title');
-  if(window.innerWidth<=1100){
-    const titleRight=title.getBoundingClientRect().right;
-    const screenRight=window.innerWidth;
-    const midpoint=(titleRight+screenRight)/2;
-    btn.style.left=midpoint+"px";
-    btn.style.transform="translateX(-50%) translateY(-50%)";
-  }else{
-    btn.style.left="";
-    btn.style.transform="translateY(-50%)";
-    mobileNav.style.display="";
-  }
-}
-window.addEventListener('resize',positionMenuBtn);
-window.addEventListener('load',positionMenuBtn);
-
 /* Swap social icons */
 document.querySelectorAll('.social img').forEach(img=>{
-  img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
-  img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
+	img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
+	img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
 });
 
 /* Adjust parchment height */
-function adjustParchmentHeight() {
-  document.querySelectorAll('.parchment').forEach(parchment=>{
-    const content=parchment.querySelector('.parchment-content');
-    const middle=parchment.querySelector('.parchment-middle');
-    const top=parchment.querySelector('.parchment-top');
-    const bottom=parchment.querySelector('.parchment-bottom');
-    if (!content||!middle||!top||!bottom) return;
-    const contentHeight=content.scrollHeight;
-    const topHeight=top.offsetHeight;
-    const bottomHeight=bottom.offsetHeight;
-    const middleHeight=Math.max(100, contentHeight - topHeight - bottomHeight);
-    middle.style.height=middleHeight+'px';
-  });
+function adjustParchmentHeight(){
+	document.querySelectorAll('.parchment').forEach(parchment=>{
+		const content=parchment.querySelector('.parchment-content');
+		const middle=parchment.querySelector('.parchment-middle');
+		const top=parchment.querySelector('.parchment-top');
+		const bottom=parchment.querySelector('.parchment-bottom');
+		if(!content||!middle||!top||!bottom){return;}
+		const contentHeight=content.scrollHeight;
+		const topHeight=top.offsetHeight;
+		const bottomHeight=bottom.offsetHeight;
+		const middleHeight=Math.max(100, contentHeight - topHeight - bottomHeight);
+		middle.style.height=middleHeight+'px';
+	});
 }
 window.addEventListener('load',()=>setTimeout(adjustParchmentHeight,100));
 window.addEventListener('resize',adjustParchmentHeight);
 </script>
 </body>
 </html>
+

--- a/development.html
+++ b/development.html
@@ -10,24 +10,24 @@
 <!-- End Cloudflare Web Analytics -->
 <style>
 :root {
-  --space: 2rem;
-  --gold: #d4af37;
-  --navy: #232a6f;
-  --navy-d: #1f224f;
-  --gap: 1.5rem;
+	--space: 2rem;
+	--gold: #d4af37;
+	--navy: #232a6f;
+	--navy-d: #1f224f;
+	--gap: 1.5rem;
 }
 
 html, body {height: 100%;}
 body {
-  margin: 0;
-  overflow-x: hidden;
-  font-family: system-ui, sans-serif;
-  color: #fff;
-  background: var(--navy);
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
+	margin: 0;
+	overflow-x: hidden;
+	font-family: system-ui, sans-serif;
+	color: #fff;
+	background: var(--navy);
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
 }
 footer {margin-top: auto;}
 *, *::before, *::after {user-select:none;box-sizing:border-box;}
@@ -36,262 +36,262 @@ footer {margin-top: auto;}
 section{padding:var(--space) 0;}
 
 /* =========================
-   Header
-   ========================= */
+		Header
+		========================= */
 header {
-  padding: 2rem 0;
-  position: relative;
+	padding: 2rem 0;
+	position: relative;
 }
 .nav-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 2rem;
-  height: 70px;
-  position: relative;
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 0 2rem;
+	height: 70px;
+	position: relative;
 }
 .nav-center {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  text-align: center;
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	text-align: center;
 }
 .site-title {
-  width: clamp(500px, 65%, 800px);
-  height: auto;
-  transition: transform 0.2s;
-  display: block;
-  margin: 0 auto;
+	width: clamp(500px, 65%, 800px);
+	height: auto;
+	transition: transform 0.2s;
+	display: block;
+	margin: 0 auto;
 }
 .site-title:hover {transform: scale(1.05);}
 .nav-left {
-  position: absolute;
-  right: 50%;
-  transform: translateX(-320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	right: 50%;
+	transform: translateX(-320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-right {
-  position: absolute;
-  left: 50%;
-  transform: translateX(320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	left: 50%;
+	transform: translateX(320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-links a {
-  color: #fff;
-  text-decoration: none;
-  font-weight: 600;
-  font-size: 1.25rem;
-  white-space: nowrap;
-  transition: color 0.2s;
-  cursor: pointer;
+	color: #fff;
+	text-decoration: none;
+	font-weight: 600;
+	font-size: 1.25rem;
+	white-space: nowrap;
+	transition: color 0.2s;
+	cursor: pointer;
 }
 .nav-links a:hover {color: var(--gold);}
 
 /* Mobile merged nav hidden by default */
 .nav-all {
-  display: none;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 0.5rem;
+	display: none;
+	flex-direction: column;
+	align-items: center;
+	margin-top: 0.5rem;
 }
 .nav-all a { margin: 0.5rem 0; font-size: 1.1rem; }
 
 /* Hamburger button */
 .menu-btn {
-  display: none;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  cursor: pointer;
+	display: none;
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	background: none;
+	border: none;
+	cursor: pointer;
 }
 .menu-btn span {
-  display: block;
-  width: 28px;
-  height: 3px;
-  background: #fff;
-  margin: 6px 0;
-  transition: 0.3s;
+	display: block;
+	width: 28px;
+	height: 3px;
+	background: #fff;
+	margin: 6px 0;
+	transition: 0.3s;
 }
 
 /* Mobile styles */
 @media (max-width: 1100px) {
-  .nav-left, .nav-right { display: none; }
-  .nav-container { height: auto; }
-  .nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
-  .site-title { width: clamp(300px, 80%, 500px); }
-  .menu-btn { display: block; }
-  header { padding: 1.5rem 0 0.75rem; }
+	.nav-left, .nav-right { display: none; }
+	.nav-container { height: auto; }
+	.nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
+	.site-title { width: clamp(300px, 80%, 500px); }
+	.menu-btn { display: block; }
+	header { padding: 1.5rem 0 0.75rem; }
 }
 
 /* =========================
-   Coming Soon Popup
-   ========================= */
+		Coming Soon Popup
+		========================= */
 .popup-overlay {
-  display: none;
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.7);
-  z-index: 1000;
-  justify-content: center;
-  align-items: center;
+	display: none;
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background: rgba(0, 0, 0, 0.7);
+	z-index: 1000;
+	justify-content: center;
+	align-items: center;
 }
 .popup-overlay.active {
-  display: flex;
+	display: flex;
 }
 .popup-content {
-  background: var(--navy-d);
-  border: 3px solid var(--gold);
-  border-radius: 12px;
-  padding: 2rem 3rem;
-  text-align: center;
-  max-width: 400px;
-  animation: popupSlide 0.3s ease-out;
+	background: var(--navy-d);
+	border: 3px solid var(--gold);
+	border-radius: 12px;
+	padding: 2rem 3rem;
+	text-align: center;
+	max-width: 400px;
+	animation: popupSlide 0.3s ease-out;
 }
 @keyframes popupSlide {
-  from {
-    transform: translateY(-50px);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
+	from {
+		transform: translateY(-50px);
+		opacity: 0;
+	}
+	to {
+		transform: translateY(0);
+		opacity: 1;
+	}
 }
 .popup-content h2 {
-  color: var(--gold);
-  margin: 0 0 1rem;
-  font-size: 2rem;
+	color: var(--gold);
+	margin: 0 0 1rem;
+	font-size: 2rem;
 }
 .popup-content p {
-  color: #ddd;
-  margin: 0 0 1.5rem;
-  font-size: 1.1rem;
+	color: #ddd;
+	margin: 0 0 1.5rem;
+	font-size: 1.1rem;
 }
 .popup-close {
-  background: var(--gold);
-  color: var(--navy);
-  border: none;
-  padding: 0.75rem 2rem;
-  font-size: 1rem;
-  font-weight: 600;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: transform 0.2s;
+	background: var(--gold);
+	color: var(--navy);
+	border: none;
+	padding: 0.75rem 2rem;
+	font-size: 1rem;
+	font-weight: 600;
+	border-radius: 6px;
+	cursor: pointer;
+	transition: transform 0.2s;
 }
 .popup-close:hover {
-  transform: scale(1.05);
+	transform: scale(1.05);
 }
 
 /* =========================
-   Social bar
-   ========================= */
+		Social bar
+		========================= */
 .social-section {background: var(--navy-d);padding: 0.75rem 0;}
 .social {display:flex;justify-content:center;gap:1.5rem;margin:0;padding:0;list-style:none;}
 .social img{height:48px;transition:transform .2s;}
 .social img:hover{transform:scale(1.1);}
 
 /* =========================
-   Roadmap + Timeline Layout
-   ========================= */
+		Roadmap + Timeline Layout
+		========================= */
 .roadmap-section {padding: var(--space) 0;}
 .roadmap-wrap{
-  max-width:1200px;
-  margin:0 auto;
-  padding:0 3rem;
+	max-width:1200px;
+	margin:0 auto;
+	padding:0 3rem;
 }
 
 .timeline-roadmap {
-  display: flex;
-  align-items: flex-start;
-  gap: 2rem;
-  flex-wrap: nowrap;
+	display: flex;
+	align-items: flex-start;
+	gap: 2rem;
+	flex-wrap: nowrap;
 }
 @media (max-width: 1200px) {
-  .timeline-roadmap {
-    flex-direction: column;
-    align-items: center;
-  }
+	.timeline-roadmap {
+		flex-direction: column;
+		align-items: center;
+	}
 }
 
 .timeline {
-  flex: 1;
-  min-width: 250px;
-  text-align: left;
-  padding-left: 1.5rem;
-  border-left: 3px solid var(--gold);
+	flex: 1;
+	min-width: 250px;
+	text-align: left;
+	padding-left: 1.5rem;
+	border-left: 3px solid var(--gold);
 }
 .timeline-entry {
-  margin: 1.5rem 0;
+	margin: 1.5rem 0;
 }
 .timeline-entry h3 {
-  margin: 0;
-  font-size: 1.3rem;
-  color: var(--gold);
+	margin: 0;
+	font-size: 1.3rem;
+	color: var(--gold);
 }
 .timeline-entry p {
-  margin: 0.25rem 0 0;
-  font-size: 1.05rem;
-  color: #ddd;
+	margin: 0.25rem 0 0;
+	font-size: 1.05rem;
+	color: #ddd;
 }
 
 .roadmap-image {
-  flex: 2;
-  min-width: 300px;
-  width: 100%;
-  height: auto;
-  display: block;
-  border-radius: 12px;
+	flex: 2;
+	min-width: 300px;
+	width: 100%;
+	height: auto;
+	display: block;
+	border-radius: 12px;
 }
 
 /* Tiles */
 .plan-title {
-  font-size:2.5rem;
-  color:var(--gold);
-  margin:3rem 0 0.75rem;
-  font-weight:700;
+	font-size:2.5rem;
+	color:var(--gold);
+	margin:3rem 0 0.75rem;
+	font-weight:700;
 }
 
 .plan-sub {font-size:1.15rem;color:#ddd;margin-bottom:var(--space);}
 
 .roadmap-tiles {
-  display: grid;
-  gap: var(--gap);
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  justify-content: center;
+	display: grid;
+	gap: var(--gap);
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+	justify-content: center;
 }
 @media (max-width: 950px) {
-  .roadmap-tiles { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+	.roadmap-tiles { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
 .roadmap-tile { position:relative; cursor:pointer; transition:transform 0.3s ease; display:flex; justify-content:center; }
 .roadmap-tile img {
-  width: 100%;
-  aspect-ratio: 1 / 1;
-  object-fit: cover;
-  border-radius: 6px;
-  transition: transform 0.3s ease;
+	width: 100%;
+	aspect-ratio: 1 / 1;
+	object-fit: cover;
+	border-radius: 6px;
+	transition: transform 0.3s ease;
 }
 .roadmap-tile:hover img { transform: scale(1.05); }
 
 /* Tooltip */
 .roadmap-tile .tooltip {
-  position:absolute;top:-40px;left:50%;transform:translateX(-50%);
-  background:var(--navy-d);color:#fff;padding:6px 10px;border-radius:6px;
-  font-size:0.8rem;font-weight:500;white-space:nowrap;opacity:0;visibility:hidden;
-  transition:all 0.3s ease;border:1px solid var(--gold);z-index:10;
+	position:absolute;top:-40px;left:50%;transform:translateX(-50%);
+	background:var(--navy-d);color:#fff;padding:6px 10px;border-radius:6px;
+	font-size:0.8rem;font-weight:500;white-space:nowrap;opacity:0;visibility:hidden;
+	transition:all 0.3s ease;border:1px solid var(--gold);z-index:10;
 }
 .roadmap-tile .tooltip::after {
-  content:'';position:absolute;top:100%;left:50%;transform:translateX(-50%);
-  border:5px solid transparent;border-top-color:var(--gold);
+	content:'';position:absolute;top:100%;left:50%;transform:translateX(-50%);
+	border:5px solid transparent;border-top-color:var(--gold);
 }
 .roadmap-tile:hover .tooltip {opacity:1;visibility:visible;top:-45px;}
 
@@ -300,157 +300,75 @@ footer{background:var(--navy-d);padding:2rem 0;font-size:.875rem;color:#ddd;}
 </head>
 
 <body>
-<header>
-  <div class="nav-container">
-    <div class="nav-left nav-links">
-      <a href="index.html">Home</a>
-      <a href="development.html">Development</a>
-    </div>
-    <div class="nav-center">
-      <a href="index.html">
-        <img src="title.png" alt="Sealubbers Title" class="site-title" id="site-title">
-      </a>
-    </div>
-    <div class="nav-right nav-links">
-      <a class="coming-soon-link">Testing</a>
-      <a class="coming-soon-link">Support</a>
-    </div>
-    <!-- Hamburger -->
-    <button class="menu-btn" id="menu-btn" aria-label="Toggle menu">
-      <span></span><span></span><span></span>
-    </button>
-    <!-- Mobile merged nav -->
-    <div class="nav-all nav-links" id="mobile-nav">
-      <a href="index.html">Home</a>
-      <a href="development.html">Development</a>
-      <a class="coming-soon-link">Testing</a>
-      <a class="coming-soon-link">Support</a>
-    </div>
-  </div>
-</header>
-
-<!-- Coming Soon Popup -->
-<div class="popup-overlay" id="popup">
-  <div class="popup-content">
-    <h2>Coming Soon</h2>
-    <p>This page is currently under development and will be available soon!</p>
-    <button class="popup-close" id="popup-close">Close</button>
-  </div>
-</div>
+<div id="header-placeholder"></div>
 
 <!-- Social -->
 <section class="social-section">
-  <div class="container">
-    <ul class="social">
-      <li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
-      <li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
-      <li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
-      <li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
-      <li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
-    </ul>
-  </div>
+	<div class="container">
+		<ul class="social">
+			<li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
+			<li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
+			<li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
+			<li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
+			<li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
+		</ul>
+	</div>
 </section>
 
 <!-- Roadmap Section -->
 <section class="roadmap-section">
-  <div class="roadmap-wrap">
+	<div class="roadmap-wrap">
 
-    <div class="timeline-roadmap">
-      <!-- Timeline on left -->
-      <div class="timeline">
-        <div class="timeline-entry">
-          <h3>Spring 2024</h3>
-          <p>Development of Sealubbers begins.</p>
-        </div>
-        <div class="timeline-entry">
-          <h3>Spring 2025</h3>
-          <p>Core mechanics reach a complete and playable state.</p>
-        </div>
-        <div class="timeline-entry">
-          <h3>July 2025</h3>
-          <p>First private playtest released to supporters.</p>
-        </div>
-        <div class="timeline-entry">
-          <h3>End of 2025</h3>
-          <p>Planned launch of the public demo on Steam.</p>
-        </div>
-      </div>
+		<div class="timeline-roadmap">
+			<!-- Timeline on left -->
+			<div class="timeline">
+				<div class="timeline-entry">
+					<h3>Spring 2024</h3>
+					<p>Development of Sealubbers begins.</p>
+				</div>
+				<div class="timeline-entry">
+					<h3>Spring 2025</h3>
+					<p>Core mechanics reach a complete and playable state.</p>
+				</div>
+				<div class="timeline-entry">
+					<h3>July 2025</h3>
+					<p>First private playtest released to supporters.</p>
+				</div>
+				<div class="timeline-entry">
+					<h3>End of 2025</h3>
+					<p>Planned launch of the public demo on Steam.</p>
+				</div>
+			</div>
 
-      <!-- Roadmap image on right -->
-      <img src="Roadmap.png" alt="Development Roadmap" class="roadmap-image">
-    </div>
+			<!-- Roadmap image on right -->
+			<img src="Roadmap.png" alt="Development Roadmap" class="roadmap-image">
+		</div>
 
-    <h2 class="plan-title">The Plan</h2>
-    <p class="plan-sub">Explore the roadmap by clicking each tile to view detailed information about Sealubbers' features, goals, and development progress.</p>
+		<h2 class="plan-title">The Plan</h2>
+		<p class="plan-sub">Explore the roadmap by clicking each tile to view detailed information about Sealubbers' features, goals, and development progress.</p>
 
-    <div class="roadmap-tiles">
-      <a class="roadmap-tile" href="story.html"><img src="RoadmapTile1.png" alt="Story"><div class="tooltip">Narrative and lore of Sealubbers</div></a>
-      <a class="roadmap-tile" href="world.html"><img src="RoadmapTile2.png" alt="World"><div class="tooltip">Islands, seas, and the setting of Krucia</div></a>
-      <a class="roadmap-tile" href="crew.html"><img src="RoadmapTile3.png" alt="Crew"><div class="tooltip">Recruiting and managing your crew</div></a>
-      <a class="roadmap-tile" href="explore.html"><img src="RoadmapTile4.png" alt="Explore"><div class="tooltip">Sailing and discovering the world</div></a>
-      <a class="roadmap-tile" href="combat.html"><img src="RoadmapTile5.png" alt="Combat"><div class="tooltip">Ship battles and boarding fights</div></a>
-      <a class="roadmap-tile" href="loot.html"><img src="RoadmapTile6.png" alt="Loot"><div class="tooltip">Treasure, rewards, and progression</div></a>
-      <a class="roadmap-tile" href="progress.html"><img src="RoadmapTile7.png" alt="Progress"><div class="tooltip">Leveling and long-term goals</div></a>
-      <a class="roadmap-tile" href="beyond.html"><img src="RoadmapTile8.png" alt="Beyond"><div class="tooltip">Future content and expansions</div></a>
-    </div>
-  </div>
+		<div class="roadmap-tiles">
+			<a class="roadmap-tile" href="story.html"><img src="RoadmapTile1.png" alt="Story"><div class="tooltip">Narrative and lore of Sealubbers</div></a>
+			<a class="roadmap-tile" href="world.html"><img src="RoadmapTile2.png" alt="World"><div class="tooltip">Islands, seas, and the setting of Krucia</div></a>
+			<a class="roadmap-tile" href="crew.html"><img src="RoadmapTile3.png" alt="Crew"><div class="tooltip">Recruiting and managing your crew</div></a>
+			<a class="roadmap-tile" href="explore.html"><img src="RoadmapTile4.png" alt="Explore"><div class="tooltip">Sailing and discovering the world</div></a>
+			<a class="roadmap-tile" href="combat.html"><img src="RoadmapTile5.png" alt="Combat"><div class="tooltip">Ship battles and boarding fights</div></a>
+			<a class="roadmap-tile" href="loot.html"><img src="RoadmapTile6.png" alt="Loot"><div class="tooltip">Treasure, rewards, and progression</div></a>
+			<a class="roadmap-tile" href="progress.html"><img src="RoadmapTile7.png" alt="Progress"><div class="tooltip">Leveling and long-term goals</div></a>
+			<a class="roadmap-tile" href="beyond.html"><img src="RoadmapTile8.png" alt="Beyond"><div class="tooltip">Future content and expansions</div></a>
+		</div>
+	</div>
 </section>
 
 <footer><div class="container">© 2025 Sealubbers. All rights reserved.</div></footer>
 
+<script src="header.js"></script>
+
 <script>
 /* Swap icons to gold on hover */
 document.querySelectorAll('.social img').forEach(img=>{
-  img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
-  img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
-});
-
-/* Mobile menu toggle */
-const menuBtn=document.getElementById('menu-btn');
-const mobileNav=document.getElementById('mobile-nav');
-menuBtn.addEventListener('click',()=>{
-  mobileNav.style.display = mobileNav.style.display==='flex' ? 'none' : 'flex';
-});
-
-/* Center hamburger */
-function positionMenuBtn(){
-  const btn=document.getElementById('menu-btn');
-  const title=document.getElementById('site-title');
-  if(window.innerWidth<=1100){
-    const titleRight=title.getBoundingClientRect().right;
-    const screenRight=window.innerWidth;
-    const midpoint=(titleRight+screenRight)/2;
-    btn.style.left=midpoint+"px";
-    btn.style.transform="translateX(-50%) translateY(-50%)";
-  }else{
-    btn.style.left="";
-    btn.style.transform="translateY(-50%)";
-    mobileNav.style.display="";
-  }
-}
-window.addEventListener('resize',positionMenuBtn);
-window.addEventListener('load',positionMenuBtn);
-
-/* Coming Soon Popup */
-const popup = document.getElementById('popup');
-const popupClose = document.getElementById('popup-close');
-const comingSoonLinks = document.querySelectorAll('.coming-soon-link');
-
-comingSoonLinks.forEach(link => {
-  link.addEventListener('click', (e) => {
-    e.preventDefault();
-    popup.classList.add('active');
-  });
-});
-
-popupClose.addEventListener('click', () => {
-  popup.classList.remove('active');
-});
-
-popup.addEventListener('click', (e) => {
-  if (e.target === popup) {
-    popup.classList.remove('active');
-  }
+	img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
+	img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
 });
 </script>
 </body>

--- a/explore.html
+++ b/explore.html
@@ -10,23 +10,23 @@
 <!-- End Cloudflare Web Analytics -->
 <style>
 :root {
-  --space: 2rem;
-  --gold: #d4af37;
-  --navy: #232a6f;
-  --navy-d: #1f224f;
+	--space: 2rem;
+	--gold: #d4af37;
+	--navy: #232a6f;
+	--navy-d: #1f224f;
 }
 
 html, body {height: 100%;}
 body {
-  margin: 0;
-  overflow-x: hidden;
-  font-family: system-ui, sans-serif;
-  color: #fff;
-  background: var(--navy);
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
+	margin: 0;
+	overflow-x: hidden;
+	font-family: system-ui, sans-serif;
+	color: #fff;
+	background: var(--navy);
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
 }
 footer {margin-top: auto;}
 *, *::before, *::after {user-select:none;box-sizing:border-box;}
@@ -36,294 +36,252 @@ section {padding: var(--space) 0;}
 .separator {width: 100%; height: 4px; background: var(--gold); margin: var(--space) 0;}
 
 /* =========================
-   Header
-   ========================= */
+		Header
+		========================= */
 header {
-  padding: 2rem 0;
-  position: relative;
+	padding: 2rem 0;
+	position: relative;
 }
 .nav-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 2rem;
-  height: 70px;
-  position: relative;
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 0 2rem;
+	height: 70px;
+	position: relative;
 }
 .nav-center {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  text-align: center;
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	text-align: center;
 }
 .site-title {
-  width: clamp(500px, 65%, 800px);
-  height: auto;
-  transition: transform 0.2s;
-  display: block;
-  margin: 0 auto;
+	width: clamp(500px, 65%, 800px);
+	height: auto;
+	transition: transform 0.2s;
+	display: block;
+	margin: 0 auto;
 }
 .site-title:hover {transform: scale(1.05);}
 .nav-left {
-  position: absolute;
-  right: 50%;
-  transform: translateX(-320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	right: 50%;
+	transform: translateX(-320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-right {
-  position: absolute;
-  left: 50%;
-  transform: translateX(320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	left: 50%;
+	transform: translateX(320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-links a {
-  color: #fff;
-  text-decoration: none;
-  font-weight: 600;
-  font-size: 1.25rem;
-  white-space: nowrap;
-  transition: color 0.2s;
+	color: #fff;
+	text-decoration: none;
+	font-weight: 600;
+	font-size: 1.25rem;
+	white-space: nowrap;
+	transition: color 0.2s;
 }
 .nav-links a:hover {color: var(--gold);}
 
 /* Mobile merged nav hidden by default */
 .nav-all {
-  display: none;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 0.5rem;
+	display: none;
+	flex-direction: column;
+	align-items: center;
+	margin-top: 0.5rem;
 }
 .nav-all a {margin: 0.5rem 0; font-size: 1.1rem;}
 
 /* Hamburger button */
 .menu-btn {
-  display: none;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  cursor: pointer;
+	display: none;
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	background: none;
+	border: none;
+	cursor: pointer;
 }
 .menu-btn span {
-  display: block;
-  width: 28px;
-  height: 3px;
-  background: #fff;
-  margin: 6px 0;
-  transition: 0.3s;
+	display: block;
+	width: 28px;
+	height: 3px;
+	background: #fff;
+	margin: 6px 0;
+	transition: 0.3s;
 }
 
 /* Mobile styles */
 @media (max-width: 1100px) {
-  .nav-left, .nav-right { display: none; }
-  .nav-container { height: auto; }
-  .nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
-  .site-title { width: clamp(300px, 80%, 500px); }
-  .menu-btn { display: block; }
-  header { padding: 1.5rem 0 0.75rem; }
+	.nav-left, .nav-right { display: none; }
+	.nav-container { height: auto; }
+	.nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
+	.site-title { width: clamp(300px, 80%, 500px); }
+	.menu-btn { display: block; }
+	header { padding: 1.5rem 0 0.75rem; }
 }
 
 /* =========================
-   Social bar
-   ========================= */
+		Social bar
+		========================= */
 .social-section {background: var(--navy-d); padding: 0.75rem 0;}
 .social {
-  display: flex;
-  justify-content: center;
-  gap: 1.5rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
+	display: flex;
+	justify-content: center;
+	gap: 1.5rem;
+	margin: 0;
+	padding: 0;
+	list-style: none;
 }
 .social img {height: 48px; transition: transform .2s;}
 .social img:hover {transform: scale(1.1);}
 
 /* =========================
-   Parchment
-   ========================= */
+		Parchment
+		========================= */
 .parchment {
-  max-width: 1200px;
-  margin: 0 auto;
-  position: relative;
-  line-height: 0;
-  margin-bottom: 2rem;
+	max-width: 1200px;
+	margin: 0 auto;
+	position: relative;
+	line-height: 0;
+	margin-bottom: 2rem;
 }
 .parchment-top,
 .parchment-bottom {
-  display: block;
-  width: 100%;
-  height: auto;
-  image-rendering: pixelated;
+	display: block;
+	width: 100%;
+	height: auto;
+	image-rendering: pixelated;
 }
 .parchment-middle {
-  background-image: url("page_middle.png");
-  background-repeat: repeat-y;
-  background-size: 100% auto;
-  image-rendering: pixelated;
-  display: block;
-  width: 100%;
-  position: relative;
+	background-image: url("page_middle.png");
+	background-repeat: repeat-y;
+	background-size: 100% auto;
+	image-rendering: pixelated;
+	display: block;
+	width: 100%;
+	position: relative;
 }
 .parchment-content {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 92%;
-  max-width: 92%;
-  padding: 2rem;
-  color: #3c3629;
-  text-align: center;
-  font-size: 1.25rem;
-  line-height: 1.7;
+	position: absolute;
+	top: 0;
+	left: 50%;
+	transform: translateX(-50%);
+	width: 92%;
+	max-width: 92%;
+	padding: 2rem;
+	color: #3c3629;
+	text-align: center;
+	font-size: 1.25rem;
+	line-height: 1.7;
 }
 .parchment-content h1 {
-  font-size: 2.5rem;
-  margin: 1rem 0;
-  color: #3c3629;
+	font-size: 2.5rem;
+	margin: 1rem 0;
+	color: #3c3629;
 }
 .parchment-content h2 {
-  font-size: 1.75rem;
-  margin: 2rem 0 1rem;
-  color: #3c3629;
+	font-size: 1.75rem;
+	margin: 2rem 0 1rem;
+	color: #3c3629;
 }
 .parchment-content p {
-  margin: 0 0 1.25rem;
-  font-size: 1.1rem;
-  line-height: 1.6;
+	margin: 0 0 1.25rem;
+	font-size: 1.1rem;
+	line-height: 1.6;
 }
 
 /* =========================
-   Footer
-   ========================= */
+		Footer
+		========================= */
 footer {background: var(--navy-d); padding: 2rem 0; font-size: .875rem; color: #ddd;}
 </style>
 </head>
 
 <body>
-<header>
-  <div class="nav-container">
-    <div class="nav-left nav-links">
-      <a href="development.html">Development</a>
-    </div>
-    <div class="nav-center">
-      <a href="index.html">
-        <img src="title.png" alt="Sealubbers Title" class="site-title" id="site-title">
-      </a>
-    </div>
-    <div class="nav-right nav-links"></div>
-    <!-- Hamburger -->
-    <button class="menu-btn" id="menu-btn" aria-label="Toggle menu">
-      <span></span><span></span><span></span>
-    </button>
-    <div class="nav-all nav-links" id="mobile-nav">
-      <a href="development.html">Development</a>
-    </div>
-  </div>
-</header>
+<div id="header-placeholder"></div>
 
 <!-- Social -->
 <section class="social-section">
-  <div class="container">
-    <ul class="social">
-      <li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
-      <li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
-      <li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
-      <li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
-      <li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
-    </ul>
-  </div>
+	<div class="container">
+		<ul class="social">
+			<li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
+			<li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
+			<li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
+			<li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
+			<li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
+		</ul>
+	</div>
 </section>
 
 <!-- Explore Content -->
 <section>
-  <div class="parchment">
-    <img src="page_top.png" alt="" class="parchment-top">
-    <div class="parchment-middle"></div>
-    <img src="page_bottom.png" alt="" class="parchment-bottom">
-    <div class="parchment-content">
-      <h1>Exploration in Krucia</h1>
-      <p>The seas of Krucia are endless, and every voyage is your own to chart. Exploration is not just about sailing from one port to another — it’s about uncovering stories, solving mysteries, and carving your path across unmarked waters. The world does not hand you a map; you create it as you go.</p>
+	<div class="parchment">
+		<img src="page_top.png" alt="" class="parchment-top">
+		<div class="parchment-middle"></div>
+		<img src="page_bottom.png" alt="" class="parchment-bottom">
+		<div class="parchment-content">
+			<h1>Exploration in Krucia</h1>
+			<p>The seas of Krucia are endless, and every voyage is your own to chart. Exploration is not just about sailing from one port to another — it’s about uncovering stories, solving mysteries, and carving your path across unmarked waters. The world does not hand you a map; you create it as you go.</p>
 
-      <h2>Quests Across the Seas</h2>
-      <p>Quests are scattered everywhere, waiting to be discovered. A tavern keeper might whisper about trouble brewing on the next island. A sailor on the docks may offer you a job. Your own crew could ask for help with a personal matter. Sometimes you’ll find a note washed up on shore, pointing toward hidden riches.</p>
-      <p>Quests take many forms. Some will send you chasing pirates or delivering goods through dangerous waters. Others may lead you into the service of factions, shaping their power across Krucia. But the most tempting quests are the ones that dangle treasure — promises of forgotten gold, locked chests, and secrets buried long ago.</p>
+			<h2>Quests Across the Seas</h2>
+			<p>Quests are scattered everywhere, waiting to be discovered. A tavern keeper might whisper about trouble brewing on the next island. A sailor on the docks may offer you a job. Your own crew could ask for help with a personal matter. Sometimes you’ll find a note washed up on shore, pointing toward hidden riches.</p>
+			<p>Quests take many forms. Some will send you chasing pirates or delivering goods through dangerous waters. Others may lead you into the service of factions, shaping their power across Krucia. But the most tempting quests are the ones that dangle treasure — promises of forgotten gold, locked chests, and secrets buried long ago.</p>
 
-      <h2>Exploring and Charting</h2>
-      <p>From the very beginning, every horizon is open. There are no locked gates or invisible walls — only the natural dangers of storms, reefs, fog, and hostile ships. As you sail, you chart the seas yourself. Islands, towns, hazards, and landmarks are added to your map only once you find them. No two maps are the same, because every captain explores differently.</p>
-      <p>Exploration is more than filling blank spaces. You’ll stumble upon strange ruins, shipwrecks, and caves. Some hold nothing but bones and stories. Others conceal gold, artifacts, or clues that point you onward. The seas are alive with drifting barrels, derelict rafts, and passing convoys — chance encounters that can help or hinder your voyage.</p>
+			<h2>Exploring and Charting</h2>
+			<p>From the very beginning, every horizon is open. There are no locked gates or invisible walls — only the natural dangers of storms, reefs, fog, and hostile ships. As you sail, you chart the seas yourself. Islands, towns, hazards, and landmarks are added to your map only once you find them. No two maps are the same, because every captain explores differently.</p>
+			<p>Exploration is more than filling blank spaces. You’ll stumble upon strange ruins, shipwrecks, and caves. Some hold nothing but bones and stories. Others conceal gold, artifacts, or clues that point you onward. The seas are alive with drifting barrels, derelict rafts, and passing convoys — chance encounters that can help or hinder your voyage.</p>
 
-      <h2>The Hunt for Treasure</h2>
-      <p>Treasure is never simply handed to you. Clues come in fragments — a torn map, a riddle carved into wood, a half-remembered song. Following them may lead you across half the ocean, piecing together hints until the final secret is revealed. Some clues are straightforward, others twist and deceive, rewarding only those who pay attention.</p>
-      <p>The treasures themselves vary. You might unearth a chest of gold, a weapon with history, or a strange artifact left behind by Asteros. Each discovery feels earned, because it was you who puzzled out the trail and braved the seas to reach it.</p>
+			<h2>The Hunt for Treasure</h2>
+			<p>Treasure is never simply handed to you. Clues come in fragments — a torn map, a riddle carved into wood, a half-remembered song. Following them may lead you across half the ocean, piecing together hints until the final secret is revealed. Some clues are straightforward, others twist and deceive, rewarding only those who pay attention.</p>
+			<p>The treasures themselves vary. You might unearth a chest of gold, a weapon with history, or a strange artifact left behind by Asteros. Each discovery feels earned, because it was you who puzzled out the trail and braved the seas to reach it.</p>
 
-      <h2>Landmarks and Wonders</h2>
-      <p>The world of Krucia is filled with landmarks, both natural and man-made. A volcano that shakes the seas around it. Coral reefs that stretch like mazes beneath the waves. Ancient forts, toppled statues, or shrines to the stars, waiting on forgotten islands.</p>
-      <p>These places aren’t just scenery — they’re markers of progress, destinations that make the seas feel alive. Some hold secrets, others stand only as reminders of those who came before. Either way, each landmark you chart makes your map, and your story, richer.</p>
+			<h2>Landmarks and Wonders</h2>
+			<p>The world of Krucia is filled with landmarks, both natural and man-made. A volcano that shakes the seas around it. Coral reefs that stretch like mazes beneath the waves. Ancient forts, toppled statues, or shrines to the stars, waiting on forgotten islands.</p>
+			<p>These places aren’t just scenery — they’re markers of progress, destinations that make the seas feel alive. Some hold secrets, others stand only as reminders of those who came before. Either way, each landmark you chart makes your map, and your story, richer.</p>
 
-      <h2>Rewards of Exploration</h2>
-      <p>Exploration always carries risk, but the rewards go beyond gold. Every port unlocked gives you new places to rest, trade, and recruit. Every landmark you find deepens your knowledge of the world. Every treasure uncovered adds to your legend. The more you explore, the more Krucia opens itself to you — a sea of stories, waiting to be told.</p>
-    </div>
-  </div>
+			<h2>Rewards of Exploration</h2>
+			<p>Exploration always carries risk, but the rewards go beyond gold. Every port unlocked gives you new places to rest, trade, and recruit. Every landmark you find deepens your knowledge of the world. Every treasure uncovered adds to your legend. The more you explore, the more Krucia opens itself to you — a sea of stories, waiting to be told.</p>
+		</div>
+	</div>
 </section>
 
 <footer><div class="container">© 2025 Sealubbers. All rights reserved.</div></footer>
 
+<script src="header.js"></script>
+
 <script>
-/* Mobile menu toggle */
-const menuBtn=document.getElementById('menu-btn');
-const mobileNav=document.getElementById('mobile-nav');
-menuBtn.addEventListener('click',()=>{
-  mobileNav.style.display = mobileNav.style.display==='flex' ? 'none' : 'flex';
-});
-
-/* Position menu button */
-function positionMenuBtn(){
-  const btn=document.getElementById('menu-btn');
-  const title=document.getElementById('site-title');
-  if(window.innerWidth<=1100){
-    const titleRight=title.getBoundingClientRect().right;
-    const screenRight=window.innerWidth;
-    const midpoint=(titleRight+screenRight)/2;
-    btn.style.left=midpoint+"px";
-    btn.style.transform="translateX(-50%) translateY(-50%)";
-  }else{
-    btn.style.left="";
-    btn.style.transform="translateY(-50%)";
-    mobileNav.style.display="";
-  }
-}
-window.addEventListener('resize',positionMenuBtn);
-window.addEventListener('load',positionMenuBtn);
-
 /* Swap social icons */
 document.querySelectorAll('.social img').forEach(img=>{
-  img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
-  img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
+	img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
+	img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
 });
 
 /* Adjust parchment height */
-function adjustParchmentHeight() {
-  document.querySelectorAll('.parchment').forEach(parchment=>{
-    const content=parchment.querySelector('.parchment-content');
-    const middle=parchment.querySelector('.parchment-middle');
-    const top=parchment.querySelector('.parchment-top');
-    const bottom=parchment.querySelector('.parchment-bottom');
-    if (!content||!middle||!top||!bottom) return;
-    const contentHeight=content.scrollHeight;
-    const topHeight=top.offsetHeight;
-    const bottomHeight=bottom.offsetHeight;
-    const middleHeight=Math.max(100, contentHeight - topHeight - bottomHeight);
-    middle.style.height=middleHeight+'px';
-  });
+function adjustParchmentHeight(){
+	document.querySelectorAll('.parchment').forEach(parchment=>{
+		const content=parchment.querySelector('.parchment-content');
+		const middle=parchment.querySelector('.parchment-middle');
+		const top=parchment.querySelector('.parchment-top');
+		const bottom=parchment.querySelector('.parchment-bottom');
+		if(!content||!middle||!top||!bottom){return;}
+		const contentHeight=content.scrollHeight;
+		const topHeight=top.offsetHeight;
+		const bottomHeight=bottom.offsetHeight;
+		const middleHeight=Math.max(100, contentHeight - topHeight - bottomHeight);
+		middle.style.height=middleHeight+'px';
+	});
 }
 window.addEventListener('load',()=>setTimeout(adjustParchmentHeight,100));
 window.addEventListener('resize',adjustParchmentHeight);
 </script>
 </body>
 </html>
+

--- a/header.html
+++ b/header.html
@@ -1,0 +1,34 @@
+<header>
+	<div class="nav-container">
+		<div class="nav-left nav-links">
+			<a href="index.html">Home</a>
+			<a href="development.html">Development</a>
+		</div>
+		<div class="nav-center">
+			<a href="index.html">
+				<img src="title.png" alt="Sealubbers Title" class="site-title" id="site-title">
+			</a>
+		</div>
+		<div class="nav-right nav-links">
+			<a class="coming-soon-link">Testing</a>
+			<a class="coming-soon-link">Support</a>
+		</div>
+		<button class="menu-btn" id="menu-btn" aria-label="Toggle menu">
+			<span></span><span></span><span></span>
+		</button>
+		<div class="nav-all nav-links" id="mobile-nav">
+			<a href="index.html">Home</a>
+			<a href="development.html">Development</a>
+			<a class="coming-soon-link">Testing</a>
+			<a class="coming-soon-link">Support</a>
+		</div>
+	</div>
+</header>
+<div class="popup-overlay" id="popup">
+	<div class="popup-content">
+		<h2>Coming Soon</h2>
+		<p>This page is currently under development and will be available soon!</p>
+		<button class="popup-close" id="popup-close">Close</button>
+	</div>
+</div>
+

--- a/header.js
+++ b/header.js
@@ -1,0 +1,73 @@
+(() => {
+	const placeholder = document.getElementById('header-placeholder');
+	if (!placeholder) {
+		return;
+	}
+	fetch('header.html')
+		.then(response => {
+			if (!response.ok) {
+				throw new Error(`Failed to load header: ${response.status}`);
+			}
+			return response.text();
+		})
+		.then(html => {
+			placeholder.innerHTML = html;
+			initHeaderInteractions();
+		})
+		.catch(error => console.error(error));
+
+	function initHeaderInteractions() {
+		const menuBtn = document.getElementById('menu-btn');
+		const mobileNav = document.getElementById('mobile-nav');
+		if (menuBtn && mobileNav) {
+			menuBtn.addEventListener('click', () => {
+				mobileNav.style.display = mobileNav.style.display === 'flex' ? 'none' : 'flex';
+			});
+		}
+
+		function positionMenuBtn() {
+			const btn = document.getElementById('menu-btn');
+			const title = document.getElementById('site-title');
+			const nav = document.getElementById('mobile-nav');
+			if (!btn || !title || !nav) {
+				return;
+			}
+			if (window.innerWidth <= 1100) {
+				const titleRight = title.getBoundingClientRect().right;
+				const screenRight = window.innerWidth;
+				const midpoint = (titleRight + screenRight) / 2;
+				btn.style.left = `${midpoint}px`;
+				btn.style.transform = 'translateX(-50%) translateY(-50%)';
+			} else {
+				btn.style.left = '';
+				btn.style.transform = 'translateY(-50%)';
+				nav.style.display = '';
+			}
+		}
+
+		window.addEventListener('resize', positionMenuBtn);
+		window.addEventListener('load', positionMenuBtn);
+		positionMenuBtn();
+
+		const popup = document.getElementById('popup');
+		const popupClose = document.getElementById('popup-close');
+		const comingSoonLinks = document.querySelectorAll('.coming-soon-link');
+		if (popup && popupClose && comingSoonLinks.length) {
+			comingSoonLinks.forEach(link => {
+				link.addEventListener('click', event => {
+					event.preventDefault();
+					popup.classList.add('active');
+				});
+			});
+			popupClose.addEventListener('click', () => {
+				popup.classList.remove('active');
+			});
+			popup.addEventListener('click', event => {
+				if (event.target === popup) {
+					popup.classList.remove('active');
+				}
+			});
+		}
+	}
+})();
+

--- a/index.html
+++ b/index.html
@@ -13,15 +13,15 @@
 
 html, body {height: 100%;}
 body {
-  margin: 0;
-  overflow-x: hidden;
-  font-family: system-ui, sans-serif;
-  color: #fff;
-  background: var(--navy);
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
+	margin: 0;
+	overflow-x: hidden;
+	font-family: system-ui, sans-serif;
+	color: #fff;
+	background: var(--navy);
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
 }
 footer {margin-top: auto;}
 *, *::before, *::after {user-select:none;box-sizing:border-box;}
@@ -31,115 +31,115 @@ section{padding:var(--space) 0;}
 .separator{width:100%;height:4px;background:var(--gold);margin:var(--space) 0;}
 
 /* =========================
-   Header
-   ========================= */
+		Header
+		========================= */
 header {
-  padding: 2rem 0;
-  position: relative;
+	padding: 2rem 0;
+	position: relative;
 }
 .nav-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 2rem;
-  height: 70px;
-  position: relative;
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 0 2rem;
+	height: 70px;
+	position: relative;
 }
 .nav-center {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  text-align: center;
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	text-align: center;
 }
 .site-title {
-  width: clamp(500px, 65%, 800px);
-  height: auto;
-  transition: transform 0.2s;
-  display: block;
-  margin: 0 auto;
+	width: clamp(500px, 65%, 800px);
+	height: auto;
+	transition: transform 0.2s;
+	display: block;
+	margin: 0 auto;
 }
 .site-title:hover {transform: scale(1.05);}
 .nav-left {
-  position: absolute;
-  right: 50%;
-  transform: translateX(-320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	right: 50%;
+	transform: translateX(-320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-right {
-  position: absolute;
-  left: 50%;
-  transform: translateX(320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	left: 50%;
+	transform: translateX(320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-links a {
-  color: #fff;
-  text-decoration: none;
-  font-weight: 600;
-  font-size: 1.25rem;
-  white-space: nowrap;
-  transition: color 0.2s;
+	color: #fff;
+	text-decoration: none;
+	font-weight: 600;
+	font-size: 1.25rem;
+	white-space: nowrap;
+	transition: color 0.2s;
 }
 .nav-links a:hover {color: var(--gold);}
 
 /* Mobile merged nav hidden by default */
 .nav-all {
-  display: none;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 0.5rem;
+	display: none;
+	flex-direction: column;
+	align-items: center;
+	margin-top: 0.5rem;
 }
 .nav-all a { margin: 0.5rem 0; font-size: 1.1rem; }
 
 /* Hamburger button */
 .menu-btn {
-  display: none;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  cursor: pointer;
+	display: none;
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	background: none;
+	border: none;
+	cursor: pointer;
 }
 .menu-btn span {
-  display: block;
-  width: 28px;
-  height: 3px;
-  background: #fff;
-  margin: 6px 0;
-  transition: 0.3s;
+	display: block;
+	width: 28px;
+	height: 3px;
+	background: #fff;
+	margin: 6px 0;
+	transition: 0.3s;
 }
 
 /* Mobile styles */
 @media (max-width: 1100px) {
-  .nav-left, .nav-right { display: none; }
-  .nav-container { height: auto; }
-  .nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
-  .site-title { width: clamp(300px, 80%, 500px); }
-  .menu-btn { display: block; }
-  header { padding: 1.5rem 0 0.75rem; }
+	.nav-left, .nav-right { display: none; }
+	.nav-container { height: auto; }
+	.nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
+	.site-title { width: clamp(300px, 80%, 500px); }
+	.menu-btn { display: block; }
+	header { padding: 1.5rem 0 0.75rem; }
 }
 
 /* =========================
-   Social bar
-   ========================= */
+		Social bar
+		========================= */
 .social-section {background: var(--navy-d);padding: 0.75rem 0;}
 .social {display:flex;justify-content:center;gap:1.5rem;margin:0;padding:0;list-style:none;}
 .social img{height:48px;transition:transform .2s;}
 .social img:hover{transform:scale(1.1);}
 
 /* =========================
-   Description
-   ========================= */
+		Description
+		========================= */
 .description p{margin:0 0 1.25rem;font-size:1.125rem;}
 .btn{display:inline-block;background:var(--gold);color:#000;font-weight:700;padding:.75rem 1.5rem;border-radius:8px;text-decoration:none;}
 
 /* =========================
-   Screenshots
-   ========================= */
+		Screenshots
+		========================= */
 .screenshots{display:grid;grid-template-columns:repeat(2,1fr);gap:2rem;max-width:1000px;margin:var(--space) auto;}
 .screenshots figure{margin:0;cursor:pointer;transition:transform .3s;}
 .screenshots figure:hover{transform:scale(1.03);}
@@ -148,8 +148,8 @@ header {
 @media(max-width:900px){.screenshots{grid-template-columns:1fr;}}
 
 /* =========================
-   FAQ
-   ========================= */
+		FAQ
+		========================= */
 #faq-title{cursor:pointer;font-size:2rem;color:var(--gold);padding:.5rem 1rem;border:2px solid var(--gold);border-radius:4px;display:inline-block;margin-bottom:1rem;transition:background .2s;}
 #faq-title:hover{background:rgba(212,175,55,.2);}
 #faq-title::after{content:"+";margin-left:.5rem;font-weight:700;}
@@ -160,162 +160,137 @@ header {
 #faq-content dd{margin:0 0 .5rem 1rem;color:#ddd;}
 
 /* =========================
-   Subscribe
-   ========================= */
+		Subscribe
+		========================= */
 .subscribe-section{padding:0;}
 .subscribe-wrapper{
-  padding:2rem 0;
-  display:flex;
-  justify-content:center;
-  align-items:center;
-  width:100%;
+	padding:2rem 0;
+	display:flex;
+	justify-content:center;
+	align-items:center;
+	width:100%;
 }
 .subscribe-wrapper iframe {
-  width: 100% !important;
-  max-width: 423px;
-  height: 182px !important;
-  margin: 0 auto;
-  display: block;
+	width: 100% !important;
+	max-width: 423px;
+	height: 182px !important;
+	margin: 0 auto;
+	display: block;
 }
 
 /* =========================
-   Contact
-   ========================= */
+		Contact
+		========================= */
 .contact-box{display:inline-block;background:var(--navy-d);padding:1rem 1.5rem;border-radius:8px;}
 .contact-box a{color:var(--gold);text-decoration:none;}
 
 /* =========================
-   Footer
-   ========================= */
+		Footer
+		========================= */
 footer{background:var(--navy-d);padding:2rem 0;font-size:.875rem;color:#ddd;}
 
 /* =========================
-   Animation
-   ========================= */
+		Animation
+		========================= */
 @keyframes pulse{0%{transform:scale(1)}50%{transform:scale(1.03)}100%{transform:scale(1)}}
 .subscribe-wrapper.pulse{animation:pulse 1s 2;}
 
 /* =========================
-   Desktop screenshot expansion
-   ========================= */
+		Desktop screenshot expansion
+		========================= */
 @media (min-width: 1101px) {
-  .description .container { max-width: 1400px; }
-  .screenshots { max-width: 1400px; }
+	.description .container { max-width: 1400px; }
+	.screenshots { max-width: 1400px; }
 }
 </style>
 </head>
 
 <body>
-<header>
-  <div class="nav-container">
-    <div class="nav-left nav-links">
-      <a href="about.html">About</a>
-      <a href="development.html">Development</a>
-    </div>
-    <div class="nav-center">
-      <a href="index.html">
-        <img src="title.png" alt="Sealubbers Title" class="site-title" id="site-title">
-      </a>
-    </div>
-    <div class="nav-right nav-links">
-      <a href="crew.html">Crew</a>
-      <a href="world.html">World</a>
-    </div>
-    <!-- Hamburger -->
-    <button class="menu-btn" id="menu-btn" aria-label="Toggle menu">
-      <span></span><span></span><span></span>
-    </button>
-    <!-- Mobile merged nav -->
-    <div class="nav-all nav-links" id="mobile-nav">
-      <a href="about.html">About</a>
-      <a href="development.html">Development</a>
-      <a href="crew.html">Crew</a>
-      <a href="world.html">World</a>
-    </div>
-  </div>
-</header>
+<div id="header-placeholder"></div>
 
 <!-- Social -->
 <section class="social-section">
-  <div class="container">
-    <ul class="social">
-      <li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
-      <li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
-      <li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
-      <li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
-      <li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
-    </ul>
-  </div>
+	<div class="container">
+		<ul class="social">
+			<li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
+			<li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
+			<li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
+			<li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
+			<li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
+		</ul>
+	</div>
 </section>
 
 <!-- Description + screenshots -->
 <section class="description">
-  <div class="container">
-    <p>Sealubbers is an open-world pirate RPG. Build your crew, battle rival ships, hunt treasure, and write your legend in the stars.</p>
-    <a class="btn" href="https://store.steampowered.com/app/3126990/Sealubbers/" target="_blank" rel="noopener">Add to Wishlist on Steam</a>
-    <div class="screenshots">
-      <figure><img src="ss1.png" alt="Creating your pirate"><figcaption>Create your pirate and customize your crew.</figcaption></figure>
-      <figure><img src="ss2.png" alt="Explore the world"><figcaption>Sail around and discover a vast open world.</figcaption></figure>
-      <figure><img src="ss3.png" alt="Ship combat"><figcaption>Battle naval vessels in thrilling ship combat.</figcaption></figure>
-      <figure><img src="ss4.png" alt="Board enemy ships"><figcaption>Board foes to steal their precious treasure.</figcaption></figure>
-    </div>
-  </div>
+	<div class="container">
+		<p>Sealubbers is an open-world pirate RPG. Build your crew, battle rival ships, hunt treasure, and write your legend in the stars.</p>
+		<a class="btn" href="https://store.steampowered.com/app/3126990/Sealubbers/" target="_blank" rel="noopener">Add to Wishlist on Steam</a>
+		<div class="screenshots">
+			<figure><img src="ss1.png" alt="Creating your pirate"><figcaption>Create your pirate and customize your crew.</figcaption></figure>
+			<figure><img src="ss2.png" alt="Explore the world"><figcaption>Sail around and discover a vast open world.</figcaption></figure>
+			<figure><img src="ss3.png" alt="Ship combat"><figcaption>Battle naval vessels in thrilling ship combat.</figcaption></figure>
+			<figure><img src="ss4.png" alt="Board enemy ships"><figcaption>Board foes to steal their precious treasure.</figcaption></figure>
+		</div>
+	</div>
 </section>
 
 <!-- Subscribe -->
 <section class="subscribe-section">
-  <div class="separator"></div>
-  <div class="subscribe-wrapper">
-    <script async src="https://subscribe-forms.beehiiv.com/embed.js"></script>
-    <iframe src="https://subscribe-forms.beehiiv.com/6816aab8-e74b-4a92-9ec1-e6691447b5ab"
-      class="beehiiv-embed"
-      data-test-id="beehiiv-embed"
-      frameborder="0"
-      scrolling="no"
-      style="width: 423px; height: 182px; margin: 0; border-radius: 0; background-color: transparent; box-shadow: 0 0 #0000;">
-    </iframe>
-  </div>
-  <div class="separator"></div>
+	<div class="separator"></div>
+	<div class="subscribe-wrapper">
+		<script async src="https://subscribe-forms.beehiiv.com/embed.js"></script>
+		<iframe src="https://subscribe-forms.beehiiv.com/6816aab8-e74b-4a92-9ec1-e6691447b5ab"
+			class="beehiiv-embed"
+			data-test-id="beehiiv-embed"
+			frameborder="0"
+			scrolling="no"
+			style="width: 423px; height: 182px; margin: 0; border-radius: 0; background-color: transparent; box-shadow: 0 0 #0000;">
+		</iframe>
+	</div>
+	<div class="separator"></div>
 </section>
 
 <!-- FAQ -->
 <section class="faq-section">
-  <div class="container">
-    <div id="faq-title">Frequently Asked Questions</div>
-    <div id="faq-content">
-      <dl>
-        <dt>When can I play Sealubbers?</dt>
-        <dd>I'm aiming to release the demo to the public by the end of September. I hope to release the full game sometime in 2026.</dd>
-        <dt>What platforms will Sealubbers support?</dt>
-        <dd>I want to release the game on PC, Mac, iOS, and Android. Possibly on console.</dd>
-        <dt>How much will Sealubbers cost?</dt>
-        <dd>The game will be free-to-play. There will be cosmetics available for purchase, but nothing that affects gameplay.</dd>
-        <dt>Is there multiplayer or co-op?</dt>
-        <dd>Not in the initial game. But I'm planning on making a multiplayer PvP gamemode inspired by games like Agar.io and Slither.io.</dd>
-      </dl>
-    </div>
-  </div>
+	<div class="container">
+		<div id="faq-title">Frequently Asked Questions</div>
+		<div id="faq-content">
+			<dl>
+				<dt>When can I play Sealubbers?</dt>
+				<dd>I'm aiming to release the demo to the public by the end of September. I hope to release the full game sometime in 2026.</dd>
+				<dt>What platforms will Sealubbers support?</dt>
+				<dd>I want to release the game on PC, Mac, iOS, and Android. Possibly on console.</dd>
+				<dt>How much will Sealubbers cost?</dt>
+				<dd>The game will be free-to-play. There will be cosmetics available for purchase, but nothing that affects gameplay.</dd>
+				<dt>Is there multiplayer or co-op?</dt>
+				<dd>Not in the initial game. But I'm planning on making a multiplayer PvP gamemode inspired by games like Agar.io and Slither.io.</dd>
+			</dl>
+		</div>
+	</div>
 </section>
 
 <!-- Contact -->
 <section class="contact-section">
-  <div class="container">
-    <div class="contact-box">Business inquiries: <a href="mailto:contact@sealubbers.com">contact@sealubbers.com</a></div>
-  </div>
+	<div class="container">
+		<div class="contact-box">Business inquiries: <a href="mailto:contact@sealubbers.com">contact@sealubbers.com</a></div>
+	</div>
 </section>
 
 <footer><div class="container">© 2025 Sealubbers. All rights reserved.</div></footer>
+
+<script src="header.js"></script>
 
 <script>
 /* FAQ toggle */
 const faqBtn=document.getElementById('faq-title');
 const faqBox=document.getElementById('faq-content');
 faqBtn.onclick=()=>{
-  faqBtn.classList.toggle('open');
-  faqBox.style.display = faqBox.style.display === 'block' ? '' : 'block';
-  if(faqBox.style.display==='block'){
-    faqBox.scrollIntoView({behavior:"smooth", block:"start"});
-  }
+	faqBtn.classList.toggle('open');
+	faqBox.style.display = faqBox.style.display === 'block' ? '' : 'block';
+	if(faqBox.style.display==='block'){
+		faqBox.scrollIntoView({behavior:"smooth", block:"start"});
+	}
 };
 
 /* Pulse once when subscribe comes into view */
@@ -324,36 +299,10 @@ new IntersectionObserver(e=>{if(e[0].isIntersecting){subWrap.classList.add('puls
 
 /* Swap icons to gold on hover */
 document.querySelectorAll('.social img').forEach(img=>{
-  img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
-  img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
+	img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
+	img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
 });
-
-/* Mobile menu toggle */
-const menuBtn=document.getElementById('menu-btn');
-const mobileNav=document.getElementById('mobile-nav');
-menuBtn.addEventListener('click',()=>{
-  mobileNav.style.display = mobileNav.style.display==='flex' ? 'none' : 'flex';
-});
-
-/* Center hamburger between title right edge & screen right edge */
-function positionMenuBtn(){
-  const btn=document.getElementById('menu-btn');
-  const title=document.getElementById('site-title');
-  if(window.innerWidth<=1100){
-    const titleRight=title.getBoundingClientRect().right;
-    const screenRight=window.innerWidth;
-    const midpoint=(titleRight+screenRight)/2;
-    btn.style.left=midpoint+"px";
-    btn.style.transform="translateX(-50%) translateY(-50%)";
-  }else{
-    btn.style.left="";
-    btn.style.transform="translateY(-50%)";
-    /* Reset mobile nav when back to desktop */
-    mobileNav.style.display="";
-  }
-}
-window.addEventListener('resize',positionMenuBtn);
-window.addEventListener('load',positionMenuBtn);
 </script>
 </body>
 </html>
+

--- a/loot.html
+++ b/loot.html
@@ -10,23 +10,23 @@
 <!-- End Cloudflare Web Analytics -->
 <style>
 :root {
-  --space: 2rem;
-  --gold: #d4af37;
-  --navy: #232a6f;
-  --navy-d: #1f224f;
+	--space: 2rem;
+	--gold: #d4af37;
+	--navy: #232a6f;
+	--navy-d: #1f224f;
 }
 
 html, body {height: 100%;}
 body {
-  margin: 0;
-  overflow-x: hidden;
-  font-family: system-ui, sans-serif;
-  color: #fff;
-  background: var(--navy);
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
+	margin: 0;
+	overflow-x: hidden;
+	font-family: system-ui, sans-serif;
+	color: #fff;
+	background: var(--navy);
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
 }
 footer {margin-top: auto;}
 *, *::before, *::after {user-select:none;box-sizing:border-box;}
@@ -36,295 +36,253 @@ section {padding: var(--space) 0;}
 .separator {width: 100%; height: 4px; background: var(--gold); margin: var(--space) 0;}
 
 /* =========================
-   Header
-   ========================= */
+		Header
+		========================= */
 header {
-  padding: 2rem 0;
-  position: relative;
+	padding: 2rem 0;
+	position: relative;
 }
 .nav-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 2rem;
-  height: 70px;
-  position: relative;
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 0 2rem;
+	height: 70px;
+	position: relative;
 }
 .nav-center {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  text-align: center;
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	text-align: center;
 }
 .site-title {
-  width: clamp(500px, 65%, 800px);
-  height: auto;
-  transition: transform 0.2s;
-  display: block;
-  margin: 0 auto;
+	width: clamp(500px, 65%, 800px);
+	height: auto;
+	transition: transform 0.2s;
+	display: block;
+	margin: 0 auto;
 }
 .site-title:hover {transform: scale(1.05);}
 .nav-left {
-  position: absolute;
-  right: 50%;
-  transform: translateX(-320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	right: 50%;
+	transform: translateX(-320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-right {
-  position: absolute;
-  left: 50%;
-  transform: translateX(320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	left: 50%;
+	transform: translateX(320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-links a {
-  color: #fff;
-  text-decoration: none;
-  font-weight: 600;
-  font-size: 1.25rem;
-  white-space: nowrap;
-  transition: color 0.2s;
+	color: #fff;
+	text-decoration: none;
+	font-weight: 600;
+	font-size: 1.25rem;
+	white-space: nowrap;
+	transition: color 0.2s;
 }
 .nav-links a:hover {color: var(--gold);}
 
 /* Mobile merged nav hidden by default */
 .nav-all {
-  display: none;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 0.5rem;
+	display: none;
+	flex-direction: column;
+	align-items: center;
+	margin-top: 0.5rem;
 }
 .nav-all a {margin: 0.5rem 0; font-size: 1.1rem;}
 
 /* Hamburger button */
 .menu-btn {
-  display: none;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  cursor: pointer;
+	display: none;
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	background: none;
+	border: none;
+	cursor: pointer;
 }
 .menu-btn span {
-  display: block;
-  width: 28px;
-  height: 3px;
-  background: #fff;
-  margin: 6px 0;
-  transition: 0.3s;
+	display: block;
+	width: 28px;
+	height: 3px;
+	background: #fff;
+	margin: 6px 0;
+	transition: 0.3s;
 }
 
 /* Mobile styles */
 @media (max-width: 1100px) {
-  .nav-left, .nav-right { display: none; }
-  .nav-container { height: auto; }
-  .nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
-  .site-title { width: clamp(300px, 80%, 500px); }
-  .menu-btn { display: block; }
-  header { padding: 1.5rem 0 0.75rem; }
+	.nav-left, .nav-right { display: none; }
+	.nav-container { height: auto; }
+	.nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
+	.site-title { width: clamp(300px, 80%, 500px); }
+	.menu-btn { display: block; }
+	header { padding: 1.5rem 0 0.75rem; }
 }
 
 /* =========================
-   Social bar
-   ========================= */
+		Social bar
+		========================= */
 .social-section {background: var(--navy-d); padding: 0.75rem 0;}
 .social {
-  display: flex;
-  justify-content: center;
-  gap: 1.5rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
+	display: flex;
+	justify-content: center;
+	gap: 1.5rem;
+	margin: 0;
+	padding: 0;
+	list-style: none;
 }
 .social img {height: 48px; transition: transform .2s;}
 .social img:hover {transform: scale(1.1);}
 
 /* =========================
-   Parchment
-   ========================= */
+		Parchment
+		========================= */
 .parchment {
-  max-width: 1200px;
-  margin: 0 auto;
-  position: relative;
-  line-height: 0;
-  margin-bottom: 2rem;
+	max-width: 1200px;
+	margin: 0 auto;
+	position: relative;
+	line-height: 0;
+	margin-bottom: 2rem;
 }
 .parchment-top,
 .parchment-bottom {
-  display: block;
-  width: 100%;
-  height: auto;
-  image-rendering: pixelated;
+	display: block;
+	width: 100%;
+	height: auto;
+	image-rendering: pixelated;
 }
 .parchment-middle {
-  background-image: url("page_middle.png");
-  background-repeat: repeat-y;
-  background-size: 100% auto;
-  image-rendering: pixelated;
-  display: block;
-  width: 100%;
-  position: relative;
+	background-image: url("page_middle.png");
+	background-repeat: repeat-y;
+	background-size: 100% auto;
+	image-rendering: pixelated;
+	display: block;
+	width: 100%;
+	position: relative;
 }
 .parchment-content {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 92%;
-  max-width: 92%;
-  padding: 2rem;
-  color: #3c3629;
-  text-align: center;
-  font-size: 1.25rem;
-  line-height: 1.7;
+	position: absolute;
+	top: 0;
+	left: 50%;
+	transform: translateX(-50%);
+	width: 92%;
+	max-width: 92%;
+	padding: 2rem;
+	color: #3c3629;
+	text-align: center;
+	font-size: 1.25rem;
+	line-height: 1.7;
 }
 .parchment-content h1 {
-  font-size: 2.5rem;
-  margin: 1rem 0;
-  color: #3c3629;
+	font-size: 2.5rem;
+	margin: 1rem 0;
+	color: #3c3629;
 }
 .parchment-content h2 {
-  font-size: 1.75rem;
-  margin: 2rem 0 1rem;
-  color: #3c3629;
+	font-size: 1.75rem;
+	margin: 2rem 0 1rem;
+	color: #3c3629;
 }
 .parchment-content p {
-  margin: 0 0 1.25rem;
-  font-size: 1.1rem;
-  line-height: 1.6;
+	margin: 0 0 1.25rem;
+	font-size: 1.1rem;
+	line-height: 1.6;
 }
 
 /* =========================
-   Footer
-   ========================= */
+		Footer
+		========================= */
 footer {background: var(--navy-d); padding: 2rem 0; font-size: .875rem; color: #ddd;}
 </style>
 </head>
 
 <body>
-<header>
-  <div class="nav-container">
-    <div class="nav-left nav-links">
-      <a href="development.html">Development</a>
-    </div>
-    <div class="nav-center">
-      <a href="index.html">
-        <img src="title.png" alt="Sealubbers Title" class="site-title" id="site-title">
-      </a>
-    </div>
-    <div class="nav-right nav-links"></div>
-    <!-- Hamburger -->
-    <button class="menu-btn" id="menu-btn" aria-label="Toggle menu">
-      <span></span><span></span><span></span>
-    </button>
-    <div class="nav-all nav-links" id="mobile-nav">
-      <a href="development.html">Development</a>
-    </div>
-  </div>
-</header>
+<div id="header-placeholder"></div>
 
 <!-- Social -->
 <section class="social-section">
-  <div class="container">
-    <ul class="social">
-      <li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
-      <li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
-      <li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
-      <li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
-      <li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
-    </ul>
-  </div>
+	<div class="container">
+		<ul class="social">
+			<li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
+			<li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
+			<li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
+			<li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
+			<li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
+		</ul>
+	</div>
 </section>
 
 <!-- Loot Content -->
 <section>
-  <div class="parchment">
-    <img src="page_top.png" alt="" class="parchment-top">
-    <div class="parchment-middle"></div>
-    <img src="page_bottom.png" alt="" class="parchment-bottom">
-    <div class="parchment-content">
-      <h1>Loot in Krucia</h1>
-      <p>Every battle fought, chest opened, and quest completed in Krucia brings rewards. Loot is more than just a prize — it fuels your growth as a captain, strengthens your crew, and unlocks new paths across the seas. From gold and schematics to rare enchantments and artifacts, every piece of loot has a purpose.</p>
+	<div class="parchment">
+		<img src="page_top.png" alt="" class="parchment-top">
+		<div class="parchment-middle"></div>
+		<img src="page_bottom.png" alt="" class="parchment-bottom">
+		<div class="parchment-content">
+			<h1>Loot in Krucia</h1>
+			<p>Every battle fought, chest opened, and quest completed in Krucia brings rewards. Loot is more than just a prize — it fuels your growth as a captain, strengthens your crew, and unlocks new paths across the seas. From gold and schematics to rare enchantments and artifacts, every piece of loot has a purpose.</p>
 
-      <h2>Sources of Loot</h2>
-      <p>Loot comes from many different places: defeating enemy ships, opening treasure chests hidden on islands or beneath the waves, completing quests, discovering shipwrecks and caves, and even random events at sea like drifting barrels or washed-up crates.</p>
+			<h2>Sources of Loot</h2>
+			<p>Loot comes from many different places: defeating enemy ships, opening treasure chests hidden on islands or beneath the waves, completing quests, discovering shipwrecks and caves, and even random events at sea like drifting barrels or washed-up crates.</p>
 
-      <h2>Core Loot Types</h2>
-      <p><strong>Gold</strong> — The foundation of your fortune. Use it to hire crew, purchase upgrades, unlock quests, buy cosmetics, pay for enchantments, and pursue the game’s main objective.</p>
-      <p><strong>Schematics</strong> — Blueprints for ship upgrades, unlocking new cannons, sails, hull reinforcements, and other permanent improvements.</p>
-      <p><strong>Enchantments</strong> — Permanent boosts to crew stats that enhance effectiveness in combat, sailing, and special abilities.</p>
-      <p><strong>Cosmetics</strong> — Customization options for your ship, captain, and crewmates. Purely visual, no stat changes.</p>
-      <p><strong>Resources</strong> — Trade goods with different values between islands. Selling to the right port turns cargo into profit.</p>
-      <p><strong>Consumables / Temporary Buffs</strong> — Short-term advantages for ship or crew, useful for tough battles, storms, or long voyages.</p>
+			<h2>Core Loot Types</h2>
+			<p><strong>Gold</strong> — The foundation of your fortune. Use it to hire crew, purchase upgrades, unlock quests, buy cosmetics, pay for enchantments, and pursue the game’s main objective.</p>
+			<p><strong>Schematics</strong> — Blueprints for ship upgrades, unlocking new cannons, sails, hull reinforcements, and other permanent improvements.</p>
+			<p><strong>Enchantments</strong> — Permanent boosts to crew stats that enhance effectiveness in combat, sailing, and special abilities.</p>
+			<p><strong>Cosmetics</strong> — Customization options for your ship, captain, and crewmates. Purely visual, no stat changes.</p>
+			<p><strong>Resources</strong> — Trade goods with different values between islands. Selling to the right port turns cargo into profit.</p>
+			<p><strong>Consumables / Temporary Buffs</strong> — Short-term advantages for ship or crew, useful for tough battles, storms, or long voyages.</p>
 
-      <h2>Experience Rewards</h2>
-      <p>Loot isn’t just physical — it also comes as experience. Your <strong>captain</strong> and your <strong>crew</strong> earn XP from battles and quests, leveling up to improve stats and strengthen gifts over time.</p>
+			<h2>Experience Rewards</h2>
+			<p>Loot isn’t just physical — it also comes as experience. Your <strong>captain</strong> and your <strong>crew</strong> earn XP from battles and quests, leveling up to improve stats and strengthen gifts over time.</p>
 
-      <h2>Loot Rarity and Distribution</h2>
-      <p>Common loot like gold and resources appears frequently, while rare drops such as schematics, enchantments, and cosmetics are occasional and exciting. Some items only appear from specific enemies or regions, and certain rewards are tied to particular quests.</p>
+			<h2>Loot Rarity and Distribution</h2>
+			<p>Common loot like gold and resources appears frequently, while rare drops such as schematics, enchantments, and cosmetics are occasional and exciting. Some items only appear from specific enemies or regions, and certain rewards are tied to particular quests.</p>
 
-      <h2>The Treasure Hunt</h2>
-      <p>Krucia hides unique prizes beyond the usual spoils: ancient artifacts tied to the world’s lore, fragments of maps and riddles that point toward larger hoards, and named items with history — weapons, tools, or relics once carried by captains of legend. Each find adds to your story as a treasure-seeker on the open sea.</p>
-    </div>
-  </div>
+			<h2>The Treasure Hunt</h2>
+			<p>Krucia hides unique prizes beyond the usual spoils: ancient artifacts tied to the world’s lore, fragments of maps and riddles that point toward larger hoards, and named items with history — weapons, tools, or relics once carried by captains of legend. Each find adds to your story as a treasure-seeker on the open sea.</p>
+		</div>
+	</div>
 </section>
 
 <footer><div class="container">© 2025 Sealubbers. All rights reserved.</div></footer>
 
+<script src="header.js"></script>
+
 <script>
-/* Mobile menu toggle */
-const menuBtn=document.getElementById('menu-btn');
-const mobileNav=document.getElementById('mobile-nav');
-menuBtn.addEventListener('click',()=>{
-  mobileNav.style.display = mobileNav.style.display==='flex' ? 'none' : 'flex';
-});
-
-/* Position menu button */
-function positionMenuBtn(){
-  const btn=document.getElementById('menu-btn');
-  const title=document.getElementById('site-title');
-  if(window.innerWidth<=1100){
-    const titleRight=title.getBoundingClientRect().right;
-    const screenRight=window.innerWidth;
-    const midpoint=(titleRight+screenRight)/2;
-    btn.style.left=midpoint+"px";
-    btn.style.transform="translateX(-50%) translateY(-50%)";
-  }else{
-    btn.style.left="";
-    btn.style.transform="translateY(-50%)";
-    mobileNav.style.display="";
-  }
-}
-window.addEventListener('resize',positionMenuBtn);
-window.addEventListener('load',positionMenuBtn);
-
 /* Swap social icons */
 document.querySelectorAll('.social img').forEach(img=>{
-  img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
-  img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
+	img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
+	img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
 });
 
 /* Adjust parchment height */
-function adjustParchmentHeight() {
-  document.querySelectorAll('.parchment').forEach(parchment=>{
-    const content=parchment.querySelector('.parchment-content');
-    const middle=parchment.querySelector('.parchment-middle');
-    const top=parchment.querySelector('.parchment-top');
-    const bottom=parchment.querySelector('.parchment-bottom');
-    if (!content||!middle||!top||!bottom) return;
-    const contentHeight=content.scrollHeight;
-    const topHeight=top.offsetHeight;
-    const bottomHeight=bottom.offsetHeight;
-    const middleHeight=Math.max(100, contentHeight - topHeight - bottomHeight);
-    middle.style.height=middleHeight+'px';
-  });
+function adjustParchmentHeight(){
+	document.querySelectorAll('.parchment').forEach(parchment=>{
+		const content=parchment.querySelector('.parchment-content');
+		const middle=parchment.querySelector('.parchment-middle');
+		const top=parchment.querySelector('.parchment-top');
+		const bottom=parchment.querySelector('.parchment-bottom');
+		if(!content||!middle||!top||!bottom){return;}
+		const contentHeight=content.scrollHeight;
+		const topHeight=top.offsetHeight;
+		const bottomHeight=bottom.offsetHeight;
+		const middleHeight=Math.max(100, contentHeight - topHeight - bottomHeight);
+		middle.style.height=middleHeight+'px';
+	});
 }
 window.addEventListener('load',()=>setTimeout(adjustParchmentHeight,100));
 window.addEventListener('resize',adjustParchmentHeight);
 </script>
 </body>
 </html>
+

--- a/progress.html
+++ b/progress.html
@@ -10,23 +10,23 @@
 <!-- End Cloudflare Web Analytics -->
 <style>
 :root {
-  --space: 2rem;
-  --gold: #d4af37;
-  --navy: #232a6f;
-  --navy-d: #1f224f;
+	--space: 2rem;
+	--gold: #d4af37;
+	--navy: #232a6f;
+	--navy-d: #1f224f;
 }
 
 html, body {height: 100%;}
 body {
-  margin: 0;
-  overflow-x: hidden;
-  font-family: system-ui, sans-serif;
-  color: #fff;
-  background: var(--navy);
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
+	margin: 0;
+	overflow-x: hidden;
+	font-family: system-ui, sans-serif;
+	color: #fff;
+	background: var(--navy);
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
 }
 footer {margin-top: auto;}
 *, *::before, *::after {user-select:none;box-sizing:border-box;}
@@ -36,295 +36,253 @@ section {padding: var(--space) 0;}
 .separator {width: 100%; height: 4px; background: var(--gold); margin: var(--space) 0;}
 
 /* =========================
-   Header
-   ========================= */
+		Header
+		========================= */
 header {
-  padding: 2rem 0;
-  position: relative;
+	padding: 2rem 0;
+	position: relative;
 }
 .nav-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 2rem;
-  height: 70px;
-  position: relative;
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 0 2rem;
+	height: 70px;
+	position: relative;
 }
 .nav-center {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  text-align: center;
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	text-align: center;
 }
 .site-title {
-  width: clamp(500px, 65%, 800px);
-  height: auto;
-  transition: transform 0.2s;
-  display: block;
-  margin: 0 auto;
+	width: clamp(500px, 65%, 800px);
+	height: auto;
+	transition: transform 0.2s;
+	display: block;
+	margin: 0 auto;
 }
 .site-title:hover {transform: scale(1.05);}
 .nav-left {
-  position: absolute;
-  right: 50%;
-  transform: translateX(-320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	right: 50%;
+	transform: translateX(-320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-right {
-  position: absolute;
-  left: 50%;
-  transform: translateX(320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	left: 50%;
+	transform: translateX(320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-links a {
-  color: #fff;
-  text-decoration: none;
-  font-weight: 600;
-  font-size: 1.25rem;
-  white-space: nowrap;
-  transition: color 0.2s;
+	color: #fff;
+	text-decoration: none;
+	font-weight: 600;
+	font-size: 1.25rem;
+	white-space: nowrap;
+	transition: color 0.2s;
 }
 .nav-links a:hover {color: var(--gold);}
 
 /* Mobile merged nav hidden by default */
 .nav-all {
-  display: none;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 0.5rem;
+	display: none;
+	flex-direction: column;
+	align-items: center;
+	margin-top: 0.5rem;
 }
 .nav-all a {margin: 0.5rem 0; font-size: 1.1rem;}
 
 /* Hamburger button */
 .menu-btn {
-  display: none;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  cursor: pointer;
+	display: none;
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	background: none;
+	border: none;
+	cursor: pointer;
 }
 .menu-btn span {
-  display: block;
-  width: 28px;
-  height: 3px;
-  background: #fff;
-  margin: 6px 0;
-  transition: 0.3s;
+	display: block;
+	width: 28px;
+	height: 3px;
+	background: #fff;
+	margin: 6px 0;
+	transition: 0.3s;
 }
 
 /* Mobile styles */
 @media (max-width: 1100px) {
-  .nav-left, .nav-right { display: none; }
-  .nav-container { height: auto; }
-  .nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
-  .site-title { width: clamp(300px, 80%, 500px); }
-  .menu-btn { display: block; }
-  header { padding: 1.5rem 0 0.75rem; }
+	.nav-left, .nav-right { display: none; }
+	.nav-container { height: auto; }
+	.nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
+	.site-title { width: clamp(300px, 80%, 500px); }
+	.menu-btn { display: block; }
+	header { padding: 1.5rem 0 0.75rem; }
 }
 
 /* =========================
-   Social bar
-   ========================= */
+		Social bar
+		========================= */
 .social-section {background: var(--navy-d); padding: 0.75rem 0;}
 .social {
-  display: flex;
-  justify-content: center;
-  gap: 1.5rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
+	display: flex;
+	justify-content: center;
+	gap: 1.5rem;
+	margin: 0;
+	padding: 0;
+	list-style: none;
 }
 .social img {height: 48px; transition: transform .2s;}
 .social img:hover {transform: scale(1.1);}
 
 /* =========================
-   Parchment
-   ========================= */
+		Parchment
+		========================= */
 .parchment {
-  max-width: 1200px;
-  margin: 0 auto;
-  position: relative;
-  line-height: 0;
-  margin-bottom: 2rem;
+	max-width: 1200px;
+	margin: 0 auto;
+	position: relative;
+	line-height: 0;
+	margin-bottom: 2rem;
 }
 .parchment-top,
 .parchment-bottom {
-  display: block;
-  width: 100%;
-  height: auto;
-  image-rendering: pixelated;
+	display: block;
+	width: 100%;
+	height: auto;
+	image-rendering: pixelated;
 }
 .parchment-middle {
-  background-image: url("page_middle.png");
-  background-repeat: repeat-y;
-  background-size: 100% auto;
-  image-rendering: pixelated;
-  display: block;
-  width: 100%;
-  position: relative;
+	background-image: url("page_middle.png");
+	background-repeat: repeat-y;
+	background-size: 100% auto;
+	image-rendering: pixelated;
+	display: block;
+	width: 100%;
+	position: relative;
 }
 .parchment-content {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 92%;
-  max-width: 92%;
-  padding: 2rem;
-  color: #3c3629;
-  text-align: center;
-  font-size: 1.25rem;
-  line-height: 1.7;
+	position: absolute;
+	top: 0;
+	left: 50%;
+	transform: translateX(-50%);
+	width: 92%;
+	max-width: 92%;
+	padding: 2rem;
+	color: #3c3629;
+	text-align: center;
+	font-size: 1.25rem;
+	line-height: 1.7;
 }
 .parchment-content h1 {
-  font-size: 2.5rem;
-  margin: 1rem 0;
-  color: #3c3629;
+	font-size: 2.5rem;
+	margin: 1rem 0;
+	color: #3c3629;
 }
 .parchment-content h2 {
-  font-size: 1.75rem;
-  margin: 2rem 0 1rem;
-  color: #3c3629;
+	font-size: 1.75rem;
+	margin: 2rem 0 1rem;
+	color: #3c3629;
 }
 .parchment-content p {
-  margin: 0 0 1.25rem;
-  font-size: 1.1rem;
-  line-height: 1.6;
+	margin: 0 0 1.25rem;
+	font-size: 1.1rem;
+	line-height: 1.6;
 }
 
 /* =========================
-   Footer
-   ========================= */
+		Footer
+		========================= */
 footer {background: var(--navy-d); padding: 2rem 0; font-size: .875rem; color: #ddd;}
 </style>
 </head>
 
 <body>
-<header>
-  <div class="nav-container">
-    <div class="nav-left nav-links">
-      <a href="development.html">Development</a>
-    </div>
-    <div class="nav-center">
-      <a href="index.html">
-        <img src="title.png" alt="Sealubbers Title" class="site-title" id="site-title">
-      </a>
-    </div>
-    <div class="nav-right nav-links"></div>
-    <!-- Hamburger -->
-    <button class="menu-btn" id="menu-btn" aria-label="Toggle menu">
-      <span></span><span></span><span></span>
-    </button>
-    <div class="nav-all nav-links" id="mobile-nav">
-      <a href="development.html">Development</a>
-    </div>
-  </div>
-</header>
+<div id="header-placeholder"></div>
 
 <!-- Social -->
 <section class="social-section">
-  <div class="container">
-    <ul class="social">
-      <li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
-      <li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
-      <li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
-      <li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
-      <li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
-    </ul>
-  </div>
+	<div class="container">
+		<ul class="social">
+			<li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
+			<li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
+			<li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
+			<li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
+			<li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
+		</ul>
+	</div>
 </section>
 
 <!-- Progress Content -->
 <section>
-  <div class="parchment">
-    <img src="page_top.png" alt="" class="parchment-top">
-    <div class="parchment-middle"></div>
-    <img src="page_bottom.png" alt="" class="parchment-bottom">
-    <div class="parchment-content">
-      <h1>Progress in Krucia</h1>
-      <p>Progress in Krucia isn’t measured by a single number — it’s a web of goals, growth, and achievements that all tie back to your legend as a captain. Gold is the most obvious marker of success, but your journey will also be shaped by how your crew grows, how your ship evolves, and how the world remembers you.</p>
+	<div class="parchment">
+		<img src="page_top.png" alt="" class="parchment-top">
+		<div class="parchment-middle"></div>
+		<img src="page_bottom.png" alt="" class="parchment-bottom">
+		<div class="parchment-content">
+			<h1>Progress in Krucia</h1>
+			<p>Progress in Krucia isn’t measured by a single number — it’s a web of goals, growth, and achievements that all tie back to your legend as a captain. Gold is the most obvious marker of success, but your journey will also be shaped by how your crew grows, how your ship evolves, and how the world remembers you.</p>
 
-      <h2>The Main Objective</h2>
-      <p>At the heart of the game lies a simple promise: bring <strong>10,000 gold</strong> to Asteros, and he will write your story into the stars. This is the soft ending of the game — the moment your tale is immortalized. But gold comes and goes, and reaching it is only one measure of progress. True completion lies beyond.</p>
+			<h2>The Main Objective</h2>
+			<p>At the heart of the game lies a simple promise: bring <strong>10,000 gold</strong> to Asteros, and he will write your story into the stars. This is the soft ending of the game — the moment your tale is immortalized. But gold comes and goes, and reaching it is only one measure of progress. True completion lies beyond.</p>
 
-      <h2>Short-Term Progression</h2>
-      <p><strong>Captain Levels</strong> — Earn XP from battles, quests, and exploration. Leveling grants perks that let you refine your playstyle — whether that means becoming a sharper strategist, a stronger fighter, or a more cunning sailor.</p>
-      <p><strong>Crew Levels</strong> — Your crewmates gain XP as they sail and fight with you. Their stats increase and their gifts grow stronger, improving performance at sea and in combat.</p>
-      <p><strong>Ship Upgrades</strong> — Permanently improve your vessel with modular parts. Different cannons, sails, and reinforcements excel in different situations, letting you adapt your ship to the challenges ahead.</p>
+			<h2>Short-Term Progression</h2>
+			<p><strong>Captain Levels</strong> — Earn XP from battles, quests, and exploration. Leveling grants perks that let you refine your playstyle — whether that means becoming a sharper strategist, a stronger fighter, or a more cunning sailor.</p>
+			<p><strong>Crew Levels</strong> — Your crewmates gain XP as they sail and fight with you. Their stats increase and their gifts grow stronger, improving performance at sea and in combat.</p>
+			<p><strong>Ship Upgrades</strong> — Permanently improve your vessel with modular parts. Different cannons, sails, and reinforcements excel in different situations, letting you adapt your ship to the challenges ahead.</p>
 
-      <h2>World Progression</h2>
-      <p><strong>Factions</strong> — Your reputation rises and falls based on your actions. Favor unlocks quests, ports, and opportunities; betrayal can kindle rivalries and close doors.</p>
-      <p><strong>Exploration</strong> — Progress is visible on your maps as you chart seas and islands. Every port visited, landmark discovered, and hazard recorded deepens your mastery of Krucia.</p>
-      <p><strong>Cosmetics</strong> — Visual progress that reflects your journey. Customizations for ship, captain, and crew show the world how far you’ve come — not in stats, but in style.</p>
+			<h2>World Progression</h2>
+			<p><strong>Factions</strong> — Your reputation rises and falls based on your actions. Favor unlocks quests, ports, and opportunities; betrayal can kindle rivalries and close doors.</p>
+			<p><strong>Exploration</strong> — Progress is visible on your maps as you chart seas and islands. Every port visited, landmark discovered, and hazard recorded deepens your mastery of Krucia.</p>
+			<p><strong>Cosmetics</strong> — Visual progress that reflects your journey. Customizations for ship, captain, and crew show the world how far you’ve come — not in stats, but in style.</p>
 
-      <h2>Completion Goals</h2>
-      <p><strong>Stars in the Sky</strong> — Beyond the 10,000 gold soft ending, true completion means filling the entire sky with stars. Stars are awarded for milestones, achievements, and hidden challenges across the game, encouraging multiple journeys to light the heavens fully.</p>
-      <p><strong>Completionist Content</strong> — For those who want everything: a vast collection of cosmetics, achievements tied to quests, battles, and exploration, and optional goals that reward deep dives into every corner of the world.</p>
+			<h2>Completion Goals</h2>
+			<p><strong>Stars in the Sky</strong> — Beyond the 10,000 gold soft ending, true completion means filling the entire sky with stars. Stars are awarded for milestones, achievements, and hidden challenges across the game, encouraging multiple journeys to light the heavens fully.</p>
+			<p><strong>Completionist Content</strong> — For those who want everything: a vast collection of cosmetics, achievements tied to quests, battles, and exploration, and optional goals that reward deep dives into every corner of the world.</p>
 
-      <h2>Conclusion</h2>
-      <p>Gold may be the spark that lights your way, but progress in Krucia is about more than riches. It’s about how your captain grows, how your crew evolves, how your ship is forged, and how many stars you can claim in the sky. Every milestone pushes your story further — and every star marks your legacy.</p>
-    </div>
-  </div>
+			<h2>Conclusion</h2>
+			<p>Gold may be the spark that lights your way, but progress in Krucia is about more than riches. It’s about how your captain grows, how your crew evolves, how your ship is forged, and how many stars you can claim in the sky. Every milestone pushes your story further — and every star marks your legacy.</p>
+		</div>
+	</div>
 </section>
 
 <footer><div class="container">© 2025 Sealubbers. All rights reserved.</div></footer>
 
+<script src="header.js"></script>
+
 <script>
-/* Mobile menu toggle */
-const menuBtn=document.getElementById('menu-btn');
-const mobileNav=document.getElementById('mobile-nav');
-menuBtn.addEventListener('click',()=>{
-  mobileNav.style.display = mobileNav.style.display==='flex' ? 'none' : 'flex';
-});
-
-/* Position menu button */
-function positionMenuBtn(){
-  const btn=document.getElementById('menu-btn');
-  const title=document.getElementById('site-title');
-  if(window.innerWidth<=1100){
-    const titleRight=title.getBoundingClientRect().right;
-    const screenRight=window.innerWidth;
-    const midpoint=(titleRight+screenRight)/2;
-    btn.style.left=midpoint+"px";
-    btn.style.transform="translateX(-50%) translateY(-50%)";
-  }else{
-    btn.style.left="";
-    btn.style.transform="translateY(-50%)";
-    mobileNav.style.display="";
-  }
-}
-window.addEventListener('resize',positionMenuBtn);
-window.addEventListener('load',positionMenuBtn);
-
 /* Swap social icons */
 document.querySelectorAll('.social img').forEach(img=>{
-  img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
-  img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
+	img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
+	img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
 });
 
 /* Adjust parchment height */
-function adjustParchmentHeight() {
-  document.querySelectorAll('.parchment').forEach(parchment=>{
-    const content=parchment.querySelector('.parchment-content');
-    const middle=parchment.querySelector('.parchment-middle');
-    const top=parchment.querySelector('.parchment-top');
-    const bottom=parchment.querySelector('.parchment-bottom');
-    if (!content||!middle||!top||!bottom) return;
-    const contentHeight=content.scrollHeight;
-    const topHeight=top.offsetHeight;
-    const bottomHeight=bottom.offsetHeight;
-    const middleHeight=Math.max(100, contentHeight - topHeight - bottomHeight);
-    middle.style.height=middleHeight+'px';
-  });
+function adjustParchmentHeight(){
+	document.querySelectorAll('.parchment').forEach(parchment=>{
+		const content=parchment.querySelector('.parchment-content');
+		const middle=parchment.querySelector('.parchment-middle');
+		const top=parchment.querySelector('.parchment-top');
+		const bottom=parchment.querySelector('.parchment-bottom');
+		if(!content||!middle||!top||!bottom){return;}
+		const contentHeight=content.scrollHeight;
+		const topHeight=top.offsetHeight;
+		const bottomHeight=bottom.offsetHeight;
+		const middleHeight=Math.max(100, contentHeight - topHeight - bottomHeight);
+		middle.style.height=middleHeight+'px';
+	});
 }
 window.addEventListener('load',()=>setTimeout(adjustParchmentHeight,100));
 window.addEventListener('resize',adjustParchmentHeight);
 </script>
 </body>
 </html>
+

--- a/story.html
+++ b/story.html
@@ -13,15 +13,15 @@
 
 html, body {height: 100%;}
 body {
-  margin: 0;
-  overflow-x: hidden;
-  font-family: system-ui, sans-serif;
-  color: #fff;
-  background: var(--navy);
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
+	margin: 0;
+	overflow-x: hidden;
+	font-family: system-ui, sans-serif;
+	color: #fff;
+	background: var(--navy);
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
 }
 footer {margin-top: auto;}
 *, *::before, *::after {user-select:none;box-sizing:border-box;}
@@ -31,310 +31,261 @@ section{padding:var(--space) 0;}
 .separator{width:100%;height:4px;background:var(--gold);margin:var(--space) 0;}
 
 /* =========================
-   Header
-   ========================= */
+		Header
+		========================= */
 header {
-  padding: 2rem 0;
-  position: relative;
+	padding: 2rem 0;
+	position: relative;
 }
 .nav-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 2rem;
-  height: 70px;
-  position: relative;
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 0 2rem;
+	height: 70px;
+	position: relative;
 }
 .nav-center {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  text-align: center;
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	text-align: center;
 }
 .site-title {
-  width: clamp(500px, 65%, 800px);
-  height: auto;
-  transition: transform 0.2s;
-  display: block;
-  margin: 0 auto;
+	width: clamp(500px, 65%, 800px);
+	height: auto;
+	transition: transform 0.2s;
+	display: block;
+	margin: 0 auto;
 }
 .site-title:hover {transform: scale(1.05);}
 .nav-left {
-  position: absolute;
-  right: 50%;
-  transform: translateX(-320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	right: 50%;
+	transform: translateX(-320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-right {
-  position: absolute;
-  left: 50%;
-  transform: translateX(320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	left: 50%;
+	transform: translateX(320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-links a {
-  color: #fff;
-  text-decoration: none;
-  font-weight: 600;
-  font-size: 1.25rem;
-  white-space: nowrap;
-  transition: color 0.2s;
+	color: #fff;
+	text-decoration: none;
+	font-weight: 600;
+	font-size: 1.25rem;
+	white-space: nowrap;
+	transition: color 0.2s;
 }
 .nav-links a:hover {color: var(--gold);}
 
 /* Mobile merged nav hidden by default */
 .nav-all {
-  display: none;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 0.5rem;
+	display: none;
+	flex-direction: column;
+	align-items: center;
+	margin-top: 0.5rem;
 }
 .nav-all a { margin: 0.5rem 0; font-size: 1.1rem; }
 
 /* Hamburger button */
 .menu-btn {
-  display: none;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  cursor: pointer;
+	display: none;
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	background: none;
+	border: none;
+	cursor: pointer;
 }
 .menu-btn span {
-  display: block;
-  width: 28px;
-  height: 3px;
-  background: #fff;
-  margin: 6px 0;
-  transition: 0.3s;
+	display: block;
+	width: 28px;
+	height: 3px;
+	background: #fff;
+	margin: 6px 0;
+	transition: 0.3s;
 }
 
 /* Mobile styles */
 @media (max-width: 1100px) {
-  .nav-left, .nav-right { display: none; }
-  .nav-container { height: auto; }
-  .nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
-  .site-title { width: clamp(300px, 80%, 500px); }
-  .menu-btn { display: block; }
-  header { padding: 1.5rem 0 0.75rem; }
+	.nav-left, .nav-right { display: none; }
+	.nav-container { height: auto; }
+	.nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
+	.site-title { width: clamp(300px, 80%, 500px); }
+	.menu-btn { display: block; }
+	header { padding: 1.5rem 0 0.75rem; }
 }
 
 /* =========================
-   Social bar
-   ========================= */
+		Social bar
+		========================= */
 .social-section {background: var(--navy-d);padding: 0.75rem 0;}
 .social {display:flex;justify-content:center;gap:1.5rem;margin:0;padding:0;list-style:none;}
 .social img{height:48px;transition:transform .2s;}
 .social img:hover{transform:scale(1.1);}
 
 /* =========================
-   Parchment (3-slice system)
-   ========================= */
+		Parchment (3-slice system)
+		========================= */
 .parchment {
-  max-width: 1200px;
-  margin: 0 auto;
-  position: relative;
-  line-height: 0;
+	max-width: 1200px;
+	margin: 0 auto;
+	position: relative;
+	line-height: 0;
 }
 
 /* Top & bottom as <img> - remove inline gaps */
 .parchment-top,
 .parchment-bottom {
-  display: block;
-  width: 100%;
-  height: auto;
-  image-rendering: pixelated;
-  line-height: 0;
+	display: block;
+	width: 100%;
+	height: auto;
+	image-rendering: pixelated;
+	line-height: 0;
 }
 
 /* Middle repeats vertically and fills full width */
 .parchment-middle {
-  background-image: url("page_middle.png");
-  background-repeat: repeat-y;
-  background-size: 100% auto;
-  image-rendering: pixelated;
-  display: block;
-  width: 100%;
-  position: relative;
+	background-image: url("page_middle.png");
+	background-repeat: repeat-y;
+	background-size: 100% auto;
+	image-rendering: pixelated;
+	display: block;
+	width: 100%;
+	position: relative;
 }
 
 /* Content wrapper */
 .parchment-content {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 92%;
-  max-width: 92%;
-  padding: 2rem;
-  color: #3c3629;
-  text-align: center;
-  font-size: 1.25rem;
-  line-height: 1.7;
-  pointer-events: none;
+	position: absolute;
+	top: 0;
+	left: 50%;
+	transform: translateX(-50%);
+	width: 92%;
+	max-width: 92%;
+	padding: 2rem;
+	color: #3c3629;
+	text-align: center;
+	font-size: 1.25rem;
+	line-height: 1.7;
+	pointer-events: none;
 }
 
 .parchment-content h1 {
-  font-size: 2.5rem;
-  margin: 1rem 0;
-  color: #3c3629;
+	font-size: 2.5rem;
+	margin: 1rem 0;
+	color: #3c3629;
 }
 
 .parchment-content p {
-  margin: 0 0 1.25rem;
+	margin: 0 0 1.25rem;
 }
 
 /* =========================
-   Asteros image below parchment
-   ========================= */
+		Asteros image below parchment
+		========================= */
 .asteros-figure {
-  margin: 2rem auto 0;
-  max-width: 1200px;
+	margin: 2rem auto 0;
+	max-width: 1200px;
 }
 .asteros-figure img {
-  width: 100%;
-  height: auto;
-  display: block;
-  image-rendering: pixelated;
+	width: 100%;
+	height: auto;
+	display: block;
+	image-rendering: pixelated;
 }
 .asteros-figure figcaption {
-  margin-top: 0.5rem;
-  font-size: 1rem;
-  color: #ccc;
-  font-style: italic;
+	margin-top: 0.5rem;
+	font-size: 1rem;
+	color: #ccc;
+	font-style: italic;
 }
 
 /* =========================
-   Footer
-   ========================= */
+		Footer
+		========================= */
 footer{background:var(--navy-d);padding:2rem 0;font-size:.875rem;color:#ddd;}
 </style>
 </head>
 
 <body>
-<header>
-  <div class="nav-container">
-    <div class="nav-left nav-links">
-      <a href="development.html">Development</a>
-    </div>
-    <div class="nav-center">
-      <a href="index.html">
-        <img src="title.png" alt="Sealubbers Title" class="site-title" id="site-title">
-      </a>
-    </div>
-    <div class="nav-right nav-links"><!-- empty --></div>
-    <!-- Hamburger -->
-    <button class="menu-btn" id="menu-btn" aria-label="Toggle menu">
-      <span></span><span></span><span></span>
-    </button>
-    <!-- Mobile merged nav -->
-    <div class="nav-all nav-links" id="mobile-nav">
-      <a href="development.html">Development</a>
-    </div>
-  </div>
-</header>
+<div id="header-placeholder"></div>
 
 <!-- Social -->
 <section class="social-section">
-  <div class="container">
-    <ul class="social">
-      <li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
-      <li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
-      <li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
-      <li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
-      <li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
-    </ul>
-  </div>
+	<div class="container">
+		<ul class="social">
+			<li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
+			<li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
+			<li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
+			<li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
+			<li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
+		</ul>
+	</div>
 </section>
 
 <!-- Story -->
 <section class="story">
-  <div class="parchment">
-    <img src="page_top.png" alt="" class="parchment-top">
-    <div class="parchment-middle"></div>
-    <img src="page_bottom.png" alt="" class="parchment-bottom">
-    
-    <div class="parchment-content">
-      <h1>The Story of Sealubbers</h1>
+	<div class="parchment">
+		<img src="page_top.png" alt="" class="parchment-top">
+		<div class="parchment-middle"></div>
+		<img src="page_bottom.png" alt="" class="parchment-bottom">
 
-      <p>At the beginning of all things, there was a god named Asteros, the Starwright. Asteros had an obsession with stories: daring adventures, tragic betrayals, and foolish comedies. For ages he poured his imagination into the void, writing his stories into the stars themselves, painting the sky with constellations of epic tales.</p>
-      <p>But in time, the Starwright’s imagination ran dry. The stars grew dull and uninspired. His stories no longer stirred the heavens. For the best stories are not imagined: they are lived.</p>
-      <p>A good story is unpredictable. It takes shape as beings, each with strengths and flaws, collide in destiny. Some join together, others destroy each other. Ambition pushes them into danger for hope of reward. A good story is born from real life.</p>
-      <p>So Asteros knew what he must do. He created a world called <strong>Krucia</strong>: a crucible of seas, storms, islands, and gold. He filled it with mortals and gave them a single challenge:<br><strong>Bring me ten thousand gold, and I will write your story into the stars forever.</strong></p>
-      <p>To make things more interesting, Asteros gave each mortal a gift. Yours is the greatest of all: an immortal ship in a bottle. Uncork it, and the ship leaps to the waves, ready to sail. It cannot be destroyed. It will always return.</p>
-      <p>Now, across Krucia, mortals fight and scheme for their chance to be immortalized in the heavens. Some build fortunes through trade, sailing from port to port with holds full of goods. Others rise through politics, where power and gold are quietly won. Finally, there are those who take to plunder, tearing riches from the hands of others.</p>
-      <p>Asteros watches with anticipation, eager for the tale that unfolds.</p>
-      <p><em>When your story is written, what will the stars say about you?</em></p>
-    </div>
-  </div>
+		<div class="parchment-content">
+			<h1>The Story of Sealubbers</h1>
 
-  <figure class="asteros-figure">
-    <img src="asteros.png" alt="Asteros illustration" width="1600" height="850">
-    <figcaption>Concept art for Asteros, the Starwright.</figcaption>
-  </figure>
+			<p>At the beginning of all things, there was a god named Asteros, the Starwright. Asteros had an obsession with stories: daring adventures, tragic betrayals, and foolish comedies. For ages he poured his imagination into the void, writing his stories into the stars themselves, painting the sky with constellations of epic tales.</p>
+			<p>But in time, the Starwright’s imagination ran dry. The stars grew dull and uninspired. His stories no longer stirred the heavens. For the best stories are not imagined: they are lived.</p>
+			<p>A good story is unpredictable. It takes shape as beings, each with strengths and flaws, collide in destiny. Some join together, others destroy each other. Ambition pushes them into danger for hope of reward. A good story is born from real life.</p>
+			<p>So Asteros knew what he must do. He created a world called <strong>Krucia</strong>: a crucible of seas, storms, islands, and gold. He filled it with mortals and gave them a single challenge:<br><strong>Bring me ten thousand gold, and I will write your story into the stars forever.</strong></p>
+			<p>To make things more interesting, Asteros gave each mortal a gift. Yours is the greatest of all: an immortal ship in a bottle. Uncork it, and the ship leaps to the waves, ready to sail. It cannot be destroyed. It will always return.</p>
+			<p>Now, across Krucia, mortals fight and scheme for their chance to be immortalized in the heavens. Some build fortunes through trade, sailing from port to port with holds full of goods. Others rise through politics, where power and gold are quietly won. Finally, there are those who take to plunder, tearing riches from the hands of others.</p>
+			<p>Asteros watches with anticipation, eager for the tale that unfolds.</p>
+			<p><em>When your story is written, what will the stars say about you?</em></p>
+		</div>
+	</div>
+
+	<figure class="asteros-figure">
+		<img src="asteros.png" alt="Asteros illustration" width="1600" height="850">
+		<figcaption>Concept art for Asteros, the Starwright.</figcaption>
+	</figure>
 </section>
 
 <footer><div class="container">© 2025 Sealubbers. All rights reserved.</div></footer>
 
+<script src="header.js"></script>
+
 <script>
-/* Mobile menu toggle */
-const menuBtn=document.getElementById('menu-btn');
-const mobileNav=document.getElementById('mobile-nav');
-menuBtn.addEventListener('click',()=>{
-  mobileNav.style.display = mobileNav.style.display==='flex' ? 'none' : 'flex';
-});
-
-/* Center hamburger between title right edge & screen right edge */
-function positionMenuBtn(){
-  const btn=document.getElementById('menu-btn');
-  const title=document.getElementById('site-title');
-  if(window.innerWidth<=1100){
-    const titleRight=title.getBoundingClientRect().right;
-    const screenRight=window.innerWidth;
-    const midpoint=(titleRight+screenRight)/2;
-    btn.style.left=midpoint+"px";
-    btn.style.transform="translateX(-50%) translateY(-50%)";
-  }else{
-    btn.style.left="";
-    btn.style.transform="translateY(-50%)";
-    mobileNav.style.display="";
-  }
-}
-window.addEventListener('resize',positionMenuBtn);
-window.addEventListener('load',positionMenuBtn);
-
 /* Swap icons to gold on hover */
 document.querySelectorAll('.social img').forEach(img=>{
-  img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
-  img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
+	img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
+	img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
 });
 
 /* Adjust parchment middle height based on content */
-function adjustParchmentHeight() {
-  const parchment = document.querySelector('.parchment');
-  const content = document.querySelector('.parchment-content');
-  const middle = document.querySelector('.parchment-middle');
-  const top = document.querySelector('.parchment-top');
-  const bottom = document.querySelector('.parchment-bottom');
-  
-  if (!parchment || !content || !middle || !top || !bottom) return;
-  
-  const contentHeight = content.scrollHeight;
-  const topHeight = top.offsetHeight;
-  const bottomHeight = bottom.offsetHeight;
-  const middleHeight = Math.max(100, contentHeight - topHeight - bottomHeight);
-  
-  middle.style.height = middleHeight + 'px';
+function adjustParchmentHeight(){
+	const parchment=document.querySelector('.parchment');
+	const content=document.querySelector('.parchment-content');
+	const middle=document.querySelector('.parchment-middle');
+	const top=document.querySelector('.parchment-top');
+	const bottom=document.querySelector('.parchment-bottom');
+	if(!parchment||!content||!middle||!top||!bottom){return;}
+	const contentHeight=content.scrollHeight;
+	const topHeight=top.offsetHeight;
+	const bottomHeight=bottom.offsetHeight;
+	const middleHeight=Math.max(100, contentHeight - topHeight - bottomHeight);
+	middle.style.height=middleHeight+'px';
 }
-
-window.addEventListener('load', () => {
-  setTimeout(adjustParchmentHeight, 100);
-});
-window.addEventListener('resize', adjustParchmentHeight);
+window.addEventListener('load',()=>{setTimeout(adjustParchmentHeight,100);});
+window.addEventListener('resize',adjustParchmentHeight);
 </script>
 </body>
 </html>
+

--- a/world.html
+++ b/world.html
@@ -10,23 +10,23 @@
 <!-- End Cloudflare Web Analytics -->
 <style>
 :root {
-  --space: 2rem;
-  --gold: #d4af37;
-  --navy: #232a6f;
-  --navy-d: #1f224f;
+	--space: 2rem;
+	--gold: #d4af37;
+	--navy: #232a6f;
+	--navy-d: #1f224f;
 }
 
 html, body {height: 100%;}
 body {
-  margin: 0;
-  overflow-x: hidden;
-  font-family: system-ui, sans-serif;
-  color: #fff;
-  background: var(--navy);
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
+	margin: 0;
+	overflow-x: hidden;
+	font-family: system-ui, sans-serif;
+	color: #fff;
+	background: var(--navy);
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
 }
 footer {margin-top: auto;}
 *, *::before, *::after {user-select:none;box-sizing:border-box;}
@@ -36,423 +36,380 @@ section {padding: var(--space) 0;}
 .separator {width: 100%; height: 4px; background: var(--gold); margin: var(--space) 0;}
 
 /* =========================
-   Header
-   ========================= */
+		Header
+		========================= */
 header {
-  padding: 2rem 0;
-  position: relative;
+	padding: 2rem 0;
+	position: relative;
 }
 .nav-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 2rem;
-  height: 70px;
-  position: relative;
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 0 2rem;
+	height: 70px;
+	position: relative;
 }
 .nav-center {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  text-align: center;
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	text-align: center;
 }
 .site-title {
-  width: clamp(500px, 65%, 800px);
-  height: auto;
-  transition: transform 0.2s;
-  display: block;
-  margin: 0 auto;
+	width: clamp(500px, 65%, 800px);
+	height: auto;
+	transition: transform 0.2s;
+	display: block;
+	margin: 0 auto;
 }
 .site-title:hover {transform: scale(1.05);}
 .nav-left {
-  position: absolute;
-  right: 50%;
-  transform: translateX(-320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	right: 50%;
+	transform: translateX(-320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-right {
-  position: absolute;
-  left: 50%;
-  transform: translateX(320px) translateY(-50%);
-  top: 50%;
-  display: flex;
-  gap: 4rem;
+	position: absolute;
+	left: 50%;
+	transform: translateX(320px) translateY(-50%);
+	top: 50%;
+	display: flex;
+	gap: 4rem;
 }
 .nav-links a {
-  color: #fff;
-  text-decoration: none;
-  font-weight: 600;
-  font-size: 1.25rem;
-  white-space: nowrap;
-  transition: color 0.2s;
+	color: #fff;
+	text-decoration: none;
+	font-weight: 600;
+	font-size: 1.25rem;
+	white-space: nowrap;
+	transition: color 0.2s;
 }
 .nav-links a:hover {color: var(--gold);}
 
 /* Mobile merged nav hidden by default */
 .nav-all {
-  display: none;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 0.5rem;
+	display: none;
+	flex-direction: column;
+	align-items: center;
+	margin-top: 0.5rem;
 }
 .nav-all a {margin: 0.5rem 0; font-size: 1.1rem;}
 
 /* Hamburger button */
 .menu-btn {
-  display: none;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  cursor: pointer;
+	display: none;
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	background: none;
+	border: none;
+	cursor: pointer;
 }
 .menu-btn span {
-  display: block;
-  width: 28px;
-  height: 3px;
-  background: #fff;
-  margin: 6px 0;
-  transition: 0.3s;
+	display: block;
+	width: 28px;
+	height: 3px;
+	background: #fff;
+	margin: 6px 0;
+	transition: 0.3s;
 }
 
 /* Mobile styles */
 @media (max-width: 1100px) {
-  .nav-left, .nav-right { display: none; }
-  .nav-container { height: auto; }
-  .nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
-  .site-title { width: clamp(300px, 80%, 500px); }
-  .menu-btn { display: block; }
-  header { padding: 1.5rem 0 0.75rem; }
+	.nav-left, .nav-right { display: none; }
+	.nav-container { height: auto; }
+	.nav-center { position: static; transform: none; margin-bottom: 0.5rem; }
+	.site-title { width: clamp(300px, 80%, 500px); }
+	.menu-btn { display: block; }
+	header { padding: 1.5rem 0 0.75rem; }
 }
 
 /* =========================
-   Social bar
-   ========================= */
+		Social bar
+		========================= */
 .social-section {background: var(--navy-d); padding: 0.75rem 0;}
 .social {
-  display: flex;
-  justify-content: center;
-  gap: 1.5rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
+	display: flex;
+	justify-content: center;
+	gap: 1.5rem;
+	margin: 0;
+	padding: 0;
+	list-style: none;
 }
 .social img {height: 48px; transition: transform .2s;}
 .social img:hover {transform: scale(1.1);}
 
 /* =========================
-   Parchment
-   ========================= */
+		Parchment
+		========================= */
 .parchment {
-  max-width: 1200px;
-  margin: 0 auto;
-  position: relative;
-  line-height: 0;
-  margin-bottom: 2rem;
+	max-width: 1200px;
+	margin: 0 auto;
+	position: relative;
+	line-height: 0;
+	margin-bottom: 2rem;
 }
 .parchment-top,
 .parchment-bottom {
-  display: block;
-  width: 100%;
-  height: auto;
-  image-rendering: pixelated;
+	display: block;
+	width: 100%;
+	height: auto;
+	image-rendering: pixelated;
 }
 .parchment-middle {
-  background-image: url("page_middle.png");
-  background-repeat: repeat-y;
-  background-size: 100% auto;
-  image-rendering: pixelated;
-  display: block;
-  width: 100%;
-  position: relative;
+	background-image: url("page_middle.png");
+	background-repeat: repeat-y;
+	background-size: 100% auto;
+	image-rendering: pixelated;
+	display: block;
+	width: 100%;
+	position: relative;
 }
 .parchment-content {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 92%;
-  max-width: 92%;
-  padding: 2rem;
-  color: #3c3629;
-  text-align: center;
-  font-size: 1.25rem;
-  line-height: 1.7;
+	position: absolute;
+	top: 0;
+	left: 50%;
+	transform: translateX(-50%);
+	width: 92%;
+	max-width: 92%;
+	padding: 2rem;
+	color: #3c3629;
+	text-align: center;
+	font-size: 1.25rem;
+	line-height: 1.7;
 }
 .parchment-content h1 {
-  font-size: 2.5rem;
-  margin: 1rem 0;
-  color: #3c3629;
+	font-size: 2.5rem;
+	margin: 1rem 0;
+	color: #3c3629;
 }
 .parchment-content p {
-  margin: 0 0 1.25rem;
+	margin: 0 0 1.25rem;
 }
 
 /* Factions in columns */
 .factions {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 2rem;
-  margin-top: 2rem;
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 2rem;
+	margin-top: 2rem;
 }
 .faction {text-align: left;}
 .faction h2 {
-  font-size: 1.75rem;
-  margin-bottom: 1rem;
-  color: #3c3629;
-  text-align: center;
+	font-size: 1.75rem;
+	margin-bottom: 1rem;
+	color: #3c3629;
+	text-align: center;
 }
 .faction p {font-size: 1.1rem; line-height: 1.6;}
 
 /* Responsive columns */
 @media (max-width: 1050px) {
-  .factions {grid-template-columns: 1fr;}
+	.factions {grid-template-columns: 1fr;}
 }
 
 /* Leader image (combined) */
 .leader-figure {
-  margin: 0 auto 2rem;
-  max-width: 960px;
+	margin: 0 auto 2rem;
+	max-width: 960px;
 }
 .leader-figure img {
-  width: 100%;
-  height: auto;
-  display: block;
-  image-rendering: pixelated;
+	width: 100%;
+	height: auto;
+	display: block;
+	image-rendering: pixelated;
 }
 .leader-figure figcaption {
-  margin-top: 1rem;
-  font-size: 1rem;
-  color: #ccc;
-  font-style: italic;
+	margin-top: 1rem;
+	font-size: 1rem;
+	color: #ccc;
+	font-style: italic;
 }
 
 /* =========================
-   Page Navigation
-   ========================= */
+		Page Navigation
+		========================= */
 .page-nav {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  max-width: 1400px;
-  margin: 1rem auto 2rem;
-  padding: 0 3rem;
-  gap: 2rem;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	max-width: 1400px;
+	margin: 1rem auto 2rem;
+	padding: 0 3rem;
+	gap: 2rem;
 }
 .page-nav-link {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  text-decoration: none;
-  color: var(--gold);
-  font-size: 1.1rem;
-  font-weight: 600;
-  transition: transform 0.2s, color 0.2s;
-  padding: 0.75rem 1.25rem;
-  border: 2px solid var(--gold);
-  border-radius: 8px;
-  background: rgba(212, 175, 55, 0.1);
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	text-decoration: none;
+	color: var(--gold);
+	font-size: 1.1rem;
+	font-weight: 600;
+	transition: transform 0.2s, color 0.2s;
+	padding: 0.75rem 1.25rem;
+	border: 2px solid var(--gold);
+	border-radius: 8px;
+	background: rgba(212, 175, 55, 0.1);
 }
 .page-nav-link:hover {
-  transform: translateY(-2px);
-  background: rgba(212, 175, 55, 0.2);
+	transform: translateY(-2px);
+	background: rgba(212, 175, 55, 0.2);
 }
 .page-nav-arrow {
-  font-size: 1.5rem;
-  line-height: 1;
+	font-size: 1.5rem;
+	line-height: 1;
 }
 .page-nav-text {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
 }
 .page-nav-label {
-  font-size: 0.85rem;
-  opacity: 0.8;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+	font-size: 0.85rem;
+	opacity: 0.8;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
 }
 .page-nav-title {
-  font-size: 1.1rem;
+	font-size: 1.1rem;
 }
 @media (max-width: 600px) {
-  .page-nav {
-    flex-direction: column;
-    gap: 1rem;
-  }
-  .page-nav-link {
-    width: 100%;
-    justify-content: center;
-  }
+	.page-nav {
+		flex-direction: column;
+		gap: 1rem;
+	}
+	.page-nav-link {
+		width: 100%;
+		justify-content: center;
+	}
 }
 
 /* =========================
-   Footer
-   ========================= */
+		Footer
+		========================= */
 footer {background: var(--navy-d); padding: 2rem 0; font-size: .875rem; color: #ddd;}
 </style>
 </head>
 
 <body>
-<header>
-  <div class="nav-container">
-    <div class="nav-left nav-links">
-      <a href="development.html">Development</a>
-    </div>
-    <div class="nav-center">
-      <a href="index.html">
-        <img src="title.png" alt="Sealubbers Title" class="site-title" id="site-title">
-      </a>
-    </div>
-    <div class="nav-right nav-links"></div>
-    <!-- Hamburger -->
-    <button class="menu-btn" id="menu-btn" aria-label="Toggle menu">
-      <span></span><span></span><span></span>
-    </button>
-    <div class="nav-all nav-links" id="mobile-nav">
-      <a href="development.html">Development</a>
-    </div>
-  </div>
-</header>
+<div id="header-placeholder"></div>
 
 <!-- Social -->
 <section class="social-section">
-  <div class="container">
-    <ul class="social">
-      <li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
-      <li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
-      <li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
-      <li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
-      <li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
-    </ul>
-  </div>
+	<div class="container">
+		<ul class="social">
+			<li><a href="https://www.patreon.com/sealubbers" target="_blank" rel="noopener"><img src="patreonwhite.svg" data-white="patreonwhite.svg" data-gold="patreongold.svg" alt="Patreon"></a></li>
+			<li><a href="https://discord.gg/SsbYEbrrFZ" target="_blank" rel="noopener"><img src="discordwhite.svg" data-white="discordwhite.svg" data-gold="discordgold.svg" alt="Discord"></a></li>
+			<li><a href="https://www.youtube.com/@playsealubbers" target="_blank" rel="noopener"><img src="youtubewhite.svg" data-white="youtubewhite.svg" data-gold="youtubegold.svg" alt="YouTube"></a></li>
+			<li><a href="https://www.instagram.com/sealubbers" target="_blank" rel="noopener"><img src="instagramwhite.svg" data-white="instagramwhite.svg" data-gold="instagramgold.svg" alt="Instagram"></a></li>
+			<li><a href="https://www.tiktok.com/@sealubbers" target="_blank" rel="noopener"><img src="tiktokwhite.svg" data-white="tiktokwhite.svg" data-gold="tiktokgold.svg" alt="TikTok"></a></li>
+		</ul>
+	</div>
 </section>
 
 <!-- Intro + Factions -->
 <section>
-  <div class="parchment">
-    <img src="page_top.png" alt="" class="parchment-top">
-    <div class="parchment-middle"></div>
-    <img src="page_bottom.png" alt="" class="parchment-bottom">
-    <div class="parchment-content">
-      <h1>The World of Krucia</h1>
-      <p>Krucia is an ocean world, a vast sea scattered with countless islands, and it is overflowing with gold. You can stumble across it almost anywhere: tucked beneath rocks, glimmering inside fish, or even hidden within a cracked coconut. Treasure is abundant as well: chests rest beneath the sand, powerful artifacts lie in wait, and maps that lead to them have been left behind by the god Asteros. But it is the people who give Krucia its energy. Every island bustles with life: shipbuilders hammering at docks, tailors threading new sails and clothes, fishermen hauling in their catch, and taverns roaring with sailors. Everywhere you look, someone is striving to leave a legacy behind.</p>
+	<div class="parchment">
+		<img src="page_top.png" alt="" class="parchment-top">
+		<div class="parchment-middle"></div>
+		<img src="page_bottom.png" alt="" class="parchment-bottom">
+		<div class="parchment-content">
+			<h1>The World of Krucia</h1>
+			<p>Krucia is an ocean world, a vast sea scattered with countless islands, and it is overflowing with gold. You can stumble across it almost anywhere: tucked beneath rocks, glimmering inside fish, or even hidden within a cracked coconut. Treasure is abundant as well: chests rest beneath the sand, powerful artifacts lie in wait, and maps that lead to them have been left behind by the god Asteros. But it is the people who give Krucia its energy. Every island bustles with life: shipbuilders hammering at docks, tailors threading new sails and clothes, fishermen hauling in their catch, and taverns roaring with sailors. Everywhere you look, someone is striving to leave a legacy behind.</p>
 
-      <div class="factions">
-        <div class="faction">
-          <h2>The Royal Navy</h2>
-          <p>The Royal Navy keeps order on the seas by collecting taxes, building ports, and offering protection. Their ships are feared both for their cannons and the tolls they demand. Their leader is <strong>King Menes, the Stormcaller</strong>, once an ordinary sailor. During Krucia's first great storm, his voice carried across the sea and guided an entire fleet to safety. Since then, people have said: "The one who can be heard shall be obeyed." With his gift, Menes rose to become king.</p>
-        </div>
-        <div class="faction">
-          <h2>The Merchant Alliance</h2>
-          <p>The Merchant Alliance uses trade to grow their power. Their ships are fast, their holds are packed with goods, and their captains are always looking for new chances to profit. Leading them is <strong>Commodore Raz, the Windborne</strong>, whose sails always catch the wind. He reaches new ports before anyone else and makes deals faster than rivals can react. Raz is friendly on the surface, but he never hesitates to outsmart or outmaneuver those who get in his way.</p>
-        </div>
-        <div class="faction">
-          <h2>The Pirate Fleet</h2>
-          <p>The Pirate Fleet lives by plunder. They raid ships, burn towns, and take what they want. Their leader, <strong>Lord Nyssa the Mad</strong>, has visions of the future, though only some come true. Once, she dreamed of warships so overloaded with gunpowder that a few cannonballs would set them ablaze. Trusting the dream, she led a ragged band of scallywags against a fleet far stronger than her own, and the ships exploded exactly as she foresaw. Since then, pirates have followed her not out of loyalty, but out of fear that her next dream would have been their end.</p>
-        </div>
-      </div>
-    </div>
-  </div>
+			<div class="factions">
+				<div class="faction">
+					<h2>The Royal Navy</h2>
+					<p>The Royal Navy keeps order on the seas by collecting taxes, building ports, and offering protection. Their ships are feared both for their cannons and the tolls they demand. Their leader is <strong>King Menes, the Stormcaller</strong>, once an ordinary sailor. During Krucia's first great storm, his voice carried across the sea and guided an entire fleet to safety. Since then, people have said: "The one who can be heard shall be obeyed." With his gift, Menes rose to become king.</p>
+				</div>
+				<div class="faction">
+					<h2>The Merchant Alliance</h2>
+					<p>The Merchant Alliance uses trade to grow their power. Their ships are fast, their holds are packed with goods, and their captains are always looking for new chances to profit. Leading them is <strong>Commodore Raz, the Windborne</strong>, whose sails always catch the wind. He reaches new ports before anyone else and makes deals faster than rivals can react. Raz is friendly on the surface, but he never hesitates to outsmart or outmaneuver those who get in his way.</p>
+				</div>
+				<div class="faction">
+					<h2>The Pirate Fleet</h2>
+					<p>The Pirate Fleet lives by plunder. They raid ships, burn towns, and take what they want. Their leader, <strong>Lord Nyssa the Mad</strong>, has visions of the future, though only some come true. Once, she dreamed of warships so overloaded with gunpowder that a few cannonballs would set them ablaze. Trusting the dream, she led a ragged band of scallywags against a fleet far stronger than her own, and the ships exploded exactly as she foresaw. Since then, pirates have followed her not out of loyalty, but out of fear that her next dream would have been their end.</p>
+				</div>
+			</div>
+		</div>
+	</div>
 </section>
 
 <!-- Leaders + Crests Image -->
 <figure class="leader-figure">
-  <img src="leaders_combined.png" alt="Leaders and crests of the Royal Navy, Merchant Alliance, and Pirate Fleet">
-  <figcaption>King Menes, Commodore Raz, and Lord Nyssa with the crests of their factions - leaders of Krucia's great powers.</figcaption>
+	<img src="leaders_combined.png" alt="Leaders and crests of the Royal Navy, Merchant Alliance, and Pirate Fleet">
+	<figcaption>King Menes, Commodore Raz, and Lord Nyssa with the crests of their factions - leaders of Krucia's great powers.</figcaption>
 </figure>
 
 <!-- Life Across Krucia + A Changing World -->
 <section>
-  <div class="parchment">
-    <img src="page_top.png" alt="" class="parchment-top">
-    <div class="parchment-middle"></div>
-    <img src="page_bottom.png" alt="" class="parchment-bottom">
-    <div class="parchment-content">
-      <h1>Life Across Krucia</h1>
-      <p>The seas and islands of Krucia are packed with things to discover. You can talk to anyone you meet, and every person has their own story or opinion to share. Some will trade with you, some will try to trick you, and some will just tell you the latest gossip.</p>
-      <p>Wildlife is everywhere; fish dart through the water, birds follow your ship, whales rise from the deep, and crabs scuttle across beaches. Shipwrecks dot the sea, left behind by battles, storms, or pirates, often holding clues or treasure.</p>
-      <p>Krucia is made up of many different biomes. You'll sail through warm tropical seas, frozen waters full of ice, coasts lined with volcanoes, thick jungles, empty deserts, and colorful coral reefs. Each area looks different, feels different, and has its own dangers and surprises. Storms, whirlpools, and heavy fog can appear at sea, turning calm waters into risky passages.</p>
-      <p>Ports and towns are spread across the map. Some are small fishing villages, while others are busy trade hubs with markets, taverns, and shipyards. Each region has its own culture, clothing, and food. You'll also run into traveling merchants, rival captains, and wandering sailors who move around the map.</p>
-      <p>The world is completely free roam. From the very beginning, you can sail anywhere and explore any island. There are no borders or locked areas, just the risks of the open sea.</p>
+	<div class="parchment">
+		<img src="page_top.png" alt="" class="parchment-top">
+		<div class="parchment-middle"></div>
+		<img src="page_bottom.png" alt="" class="parchment-bottom">
+		<div class="parchment-content">
+			<h1>Life Across Krucia</h1>
+			<p>The seas and islands of Krucia are packed with things to discover. You can talk to anyone you meet, and every person has their own story or opinion to share. Some will trade with you, some will try to trick you, and some will just tell you the latest gossip.</p>
+			<p>Wildlife is everywhere; fish dart through the water, birds follow your ship, whales rise from the deep, and crabs scuttle across beaches. Shipwrecks dot the sea, left behind by battles, storms, or pirates, often holding clues or treasure.</p>
+			<p>Krucia is made up of many different biomes. You'll sail through warm tropical seas, frozen waters full of ice, coasts lined with volcanoes, thick jungles, empty deserts, and colorful coral reefs. Each area looks different, feels different, and has its own dangers and surprises. Storms, whirlpools, and heavy fog can appear at sea, turning calm waters into risky passages.</p>
+			<p>Ports and towns are spread across the map. Some are small fishing villages, while others are busy trade hubs with markets, taverns, and shipyards. Each region has its own culture, clothing, and food. You'll also run into traveling merchants, rival captains, and wandering sailors who move around the map.</p>
+			<p>The world is completely free roam. From the very beginning, you can sail anywhere and explore any island. There are no borders or locked areas, just the risks of the open sea.</p>
 
-      <h1>A Changing World</h1>
-      <p>Krucia is not a static place. The factions react to your choices. Help one side, and they may grow stronger. Betray them, and they may hunt you down. You can gain or lose their trust, and their fleets and towns will change based on your actions.</p>
-      <p>The wider world also shifts as events unfold. Ports may change hands, fleets may be wiped out, and new threats may rise. Even small actions can ripple outward, changing how others see you and how the seas themselves are shaped.</p>
-    </div>
-  </div>
+			<h1>A Changing World</h1>
+			<p>Krucia is not a static place. The factions react to your choices. Help one side, and they may grow stronger. Betray them, and they may hunt you down. You can gain or lose their trust, and their fleets and towns will change based on your actions.</p>
+			<p>The wider world also shifts as events unfold. Ports may change hands, fleets may be wiped out, and new threats may rise. Even small actions can ripple outward, changing how others see you and how the seas themselves are shaped.</p>
+		</div>
+	</div>
 </section>
 
 <!-- Page Navigation -->
 <nav class="page-nav">
-  <a href="story.html" class="page-nav-link">
-    <span class="page-nav-arrow">←</span>
-    <div class="page-nav-text">
-      <span class="page-nav-label">Return to</span>
-      <span class="page-nav-title">Story</span>
-    </div>
-  </a>
-  <a href="crew.html" class="page-nav-link">
-    <div class="page-nav-text" style="text-align: right;">
-      <span class="page-nav-label">Next Up</span>
-      <span class="page-nav-title">Crew</span>
-    </div>
-    <span class="page-nav-arrow">→</span>
-  </a>
+	<a href="story.html" class="page-nav-link">
+		<span class="page-nav-arrow">←</span>
+		<div class="page-nav-text">
+			<span class="page-nav-label">Return to</span>
+			<span class="page-nav-title">Story</span>
+		</div>
+	</a>
+	<a href="crew.html" class="page-nav-link">
+		<div class="page-nav-text" style="text-align: right;">
+			<span class="page-nav-label">Next Up</span>
+			<span class="page-nav-title">Crew</span>
+		</div>
+		<span class="page-nav-arrow">→</span>
+	</a>
 </nav>
 
 <footer><div class="container">© 2025 Sealubbers. All rights reserved.</div></footer>
 
+<script src="header.js"></script>
+
 <script>
-/* Mobile menu toggle */
-const menuBtn=document.getElementById('menu-btn');
-const mobileNav=document.getElementById('mobile-nav');
-menuBtn.addEventListener('click',()=>{
-  mobileNav.style.display = mobileNav.style.display==='flex' ? 'none' : 'flex';
-});
-
-/* Position menu button */
-function positionMenuBtn(){
-  const btn=document.getElementById('menu-btn');
-  const title=document.getElementById('site-title');
-  if(window.innerWidth<=1100){
-    const titleRight=title.getBoundingClientRect().right;
-    const screenRight=window.innerWidth;
-    const midpoint=(titleRight+screenRight)/2;
-    btn.style.left=midpoint+"px";
-    btn.style.transform="translateX(-50%) translateY(-50%)";
-  }else{
-    btn.style.left="";
-    btn.style.transform="translateY(-50%)";
-    mobileNav.style.display="";
-  }
-}
-window.addEventListener('resize',positionMenuBtn);
-window.addEventListener('load',positionMenuBtn);
-
 /* Swap social icons */
 document.querySelectorAll('.social img').forEach(img=>{
-  img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
-  img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
+	img.addEventListener('mouseenter',()=>img.src=img.dataset.gold);
+	img.addEventListener('mouseleave',()=>img.src=img.dataset.white);
 });
 
 /* Adjust parchment height */
-function adjustParchmentHeight() {
-  document.querySelectorAll('.parchment').forEach(parchment=>{
-    const content=parchment.querySelector('.parchment-content');
-    const middle=parchment.querySelector('.parchment-middle');
-    const top=parchment.querySelector('.parchment-top');
-    const bottom=parchment.querySelector('.parchment-bottom');
-    if (!content||!middle||!top||!bottom) return;
-    const contentHeight=content.scrollHeight;
-    const topHeight=top.offsetHeight;
-    const bottomHeight=bottom.offsetHeight;
-    const middleHeight=Math.max(100, contentHeight - topHeight - bottomHeight);
-    middle.style.height=middleHeight+'px';
-  });
+function adjustParchmentHeight(){
+	document.querySelectorAll('.parchment').forEach(parchment=>{
+		const content=parchment.querySelector('.parchment-content');
+		const middle=parchment.querySelector('.parchment-middle');
+		const top=parchment.querySelector('.parchment-top');
+		const bottom=parchment.querySelector('.parchment-bottom');
+		if(!content||!middle||!top||!bottom){return;}
+		const contentHeight=content.scrollHeight;
+		const topHeight=top.offsetHeight;
+		const bottomHeight=bottom.offsetHeight;
+		const middleHeight=Math.max(100, contentHeight - topHeight - bottomHeight);
+		middle.style.height=middleHeight+'px';
+	});
 }
 window.addEventListener('load',()=>setTimeout(adjustParchmentHeight,100));
 window.addEventListener('resize',adjustParchmentHeight);


### PR DESCRIPTION
## Summary
- move the shared navigation markup into a new `header.html` partial, including the coming-soon overlay
- add `header.js` to fetch the partial into a placeholder and manage menu and popup behavior
- update every page to drop the inlined header, add the placeholder, include `header.js`, and retain only page-specific scripts

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68ddec7b74c0832bb59f80edce2c86f0