### PR TITLE
Unify delay-article background with site theme

### DIFF
--- a/delay-article.html
+++ b/delay-article.html
@@ -18,7 +18,7 @@ html, body {height: 100%;}
 body {
 	margin: 0;
 	font-family: system-ui, sans-serif;
-	background: linear-gradient(180deg, #1a2060 0%, #121742 100%);
+	background: var(--navy);
 	color: #fff;
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
### Motivation
- The delay article used a unique gradient background that made the header/social bar/footer appear mismatched with the rest of the site, so the page background needs to use the shared navy theme.

### Description
- Replaced the page background in `delay-article.html` from the gradient to the site variable `var(--navy)` so the article matches the shared header, social bar, and footer styling, and preserved tab-based indentation.

### Testing
- Started a local static server with `python3 -m http.server 8000`, visually validated the page at `http://127.0.0.1:8000/delay-article.html` and captured a Playwright screenshot, and committed the change; all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d8fa19d20832bb0b94639ad06add9)